### PR TITLE
feat: Add knowledge:config command for ChromaDB settings management

### DIFF
--- a/app/Commands/KnowledgeConfigCommand.php
+++ b/app/Commands/KnowledgeConfigCommand.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands;
+
+use App\Services\KnowledgePathService;
+use LaravelZero\Framework\Commands\Command;
+
+class KnowledgeConfigCommand extends Command
+{
+    protected $signature = 'knowledge:config
+                            {action=list : Action to perform (list, get, set)}
+                            {key? : Configuration key (e.g., chromadb.enabled)}
+                            {value? : Configuration value}';
+
+    protected $description = 'Manage Knowledge configuration settings';
+
+    private const CONFIG_FILE = 'config.json';
+
+    private const DEFAULTS = [
+        'chromadb' => [
+            'enabled' => false,
+            'url' => 'http://localhost:8000',
+        ],
+        'embeddings' => [
+            'url' => 'http://localhost:8001',
+        ],
+    ];
+
+    private const VALID_KEYS = [
+        'chromadb.enabled',
+        'chromadb.url',
+        'embeddings.url',
+    ];
+
+    private const BOOLEAN_KEYS = [
+        'chromadb.enabled',
+    ];
+
+    private const URL_KEYS = [
+        'chromadb.url',
+        'embeddings.url',
+    ];
+
+    private KnowledgePathService $pathService;
+
+    public function handle(KnowledgePathService $pathService): int
+    {
+        $this->pathService = $pathService;
+        $action = $this->argument('action');
+
+        // @codeCoverageIgnoreStart
+        // Type narrowing for PHPStan - Laravel's command system ensures string
+        if (! is_string($action)) {
+            return $this->invalidAction('');
+        }
+        // @codeCoverageIgnoreEnd
+
+        return match ($action) {
+            'list' => $this->listConfig(),
+            'get' => $this->getConfig(),
+            'set' => $this->setConfig(),
+            default => $this->invalidAction($action),
+        };
+    }
+
+    private function listConfig(): int
+    {
+        $config = $this->loadConfig();
+
+        $this->line('<fg=cyan>Knowledge Configuration:</>');
+        $this->newLine();
+
+        $this->displayConfigTree($config);
+
+        return self::SUCCESS;
+    }
+
+    private function getConfig(): int
+    {
+        $key = $this->argument('key');
+
+        // Type narrowing for PHPStan
+        if (! is_string($key) || $key === '') {
+            $this->error('Key is required for get action.');
+
+            return self::FAILURE;
+        }
+
+        if (! $this->isValidKey($key)) {
+            $this->error('Invalid configuration key: '.$key);
+            $this->line('Valid keys: '.implode(', ', self::VALID_KEYS));
+
+            return self::FAILURE;
+        }
+
+        $config = $this->loadConfig();
+        $value = $this->getNestedValue($config, $key);
+
+        $this->line($this->formatValue($value));
+
+        return self::SUCCESS;
+    }
+
+    private function setConfig(): int
+    {
+        $key = $this->argument('key');
+        $value = $this->argument('value');
+
+        // Type narrowing for PHPStan
+        if (! is_string($key) || $key === '' || ! is_string($value) || $value === '') {
+            $this->error('Key and value are required for set action.');
+
+            return self::FAILURE;
+        }
+
+        if (! $this->isValidKey($key)) {
+            $this->error('Invalid configuration key: '.$key);
+            $this->line('Valid keys: '.implode(', ', self::VALID_KEYS));
+
+            return self::FAILURE;
+        }
+
+        // Validate value based on key type
+        $validationResult = $this->validateValue($key, $value);
+        if ($validationResult !== null) {
+            $this->error($validationResult);
+
+            return self::FAILURE;
+        }
+
+        $config = $this->loadConfig();
+        $typedValue = $this->parseValue($key, $value);
+        $this->setNestedValue($config, $key, $typedValue);
+
+        $this->saveConfig($config);
+
+        $this->info('Configuration updated successfully.');
+        $this->line("<fg=cyan>{$key}:</> ".$this->formatValue($typedValue));
+
+        return self::SUCCESS;
+    }
+
+    private function invalidAction(string $action): int
+    {
+        $this->error("Invalid action: {$action}");
+        $this->line('Valid actions: list, get, set');
+
+        return self::FAILURE;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadConfig(): array
+    {
+        $configPath = $this->getConfigPath();
+
+        if (! file_exists($configPath)) {
+            return self::DEFAULTS;
+        }
+
+        $content = file_get_contents($configPath);
+        // @codeCoverageIgnoreStart
+        // Defensive: file_get_contents only fails on read errors
+        if ($content === false) {
+            return self::DEFAULTS;
+        }
+        // @codeCoverageIgnoreEnd
+
+        $config = json_decode($content, true);
+        if (! is_array($config)) {
+            return self::DEFAULTS;
+        }
+
+        // Merge with defaults to ensure all keys exist
+        return array_replace_recursive(self::DEFAULTS, $config);
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function saveConfig(array $config): void
+    {
+        $knowledgeDir = $this->pathService->getKnowledgeDirectory();
+        $this->pathService->ensureDirectoryExists($knowledgeDir);
+
+        $configPath = $this->getConfigPath();
+        file_put_contents($configPath, json_encode($config, JSON_PRETTY_PRINT));
+    }
+
+    private function getConfigPath(): string
+    {
+        return $this->pathService->getKnowledgeDirectory().'/'.self::CONFIG_FILE;
+    }
+
+    private function isValidKey(string $key): bool
+    {
+        return in_array($key, self::VALID_KEYS, true);
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function getNestedValue(array $config, string $key): mixed
+    {
+        $parts = explode('.', $key);
+        $value = $config;
+
+        foreach ($parts as $part) {
+            // @codeCoverageIgnoreStart
+            // Defensive: defaults are always merged, so keys should exist
+            if (! is_array($value) || ! array_key_exists($part, $value)) {
+                return null;
+            }
+            // @codeCoverageIgnoreEnd
+            $value = $value[$part];
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function setNestedValue(array &$config, string $key, mixed $value): void
+    {
+        $parts = explode('.', $key);
+        $current = &$config;
+
+        foreach ($parts as $i => $part) {
+            if ($i === count($parts) - 1) {
+                $current[$part] = $value;
+            } else {
+                // @codeCoverageIgnoreStart
+                // Defensive: defaults are always merged, so parent keys should exist
+                if (! isset($current[$part]) || ! is_array($current[$part])) {
+                    $current[$part] = [];
+                }
+                // @codeCoverageIgnoreEnd
+                $current = &$current[$part];
+            }
+        }
+    }
+
+    private function parseValue(string $key, string $value): mixed
+    {
+        if (in_array($key, self::BOOLEAN_KEYS, true)) {
+            return $value === 'true';
+        }
+
+        return $value;
+    }
+
+    private function validateValue(string $key, string $value): ?string
+    {
+        if (in_array($key, self::BOOLEAN_KEYS, true)) {
+            if ($value !== 'true' && $value !== 'false') {
+                return "Value for {$key} must be a boolean (true or false).";
+            }
+        }
+
+        if (in_array($key, self::URL_KEYS, true)) {
+            if (! $this->isValidUrl($value)) {
+                return "Value for {$key} must be a valid URL.";
+            }
+        }
+
+        return null;
+    }
+
+    private function isValidUrl(string $url): bool
+    {
+        return filter_var($url, FILTER_VALIDATE_URL) !== false
+            && (str_starts_with($url, 'http://') || str_starts_with($url, 'https://'));
+    }
+
+    private function formatValue(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        // @codeCoverageIgnoreStart
+        // Defensive: config values should always be bool or string
+        if ($value === null) {
+            return 'null';
+        }
+
+        return (string) $value;
+        // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function displayConfigTree(array $config, string $prefix = ''): void
+    {
+        foreach ($config as $key => $value) {
+            if (is_array($value)) {
+                $this->displayConfigTree($value, $prefix.$key.'.');
+            } else {
+                $fullKey = $prefix.$key;
+                $formattedValue = $this->formatValue($value);
+                $this->line("<fg=cyan>{$fullKey}:</> {$formattedValue}");
+            }
+        }
+    }
+}

--- a/tests/Feature/Commands/KnowledgeConfigCommandTest.php
+++ b/tests/Feature/Commands/KnowledgeConfigCommandTest.php
@@ -1,0 +1,390 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\KnowledgePathService;
+
+beforeEach(function () {
+    // Use a temporary config directory for testing
+    $this->testConfigDir = sys_get_temp_dir().'/knowledge-config-test-'.uniqid();
+    mkdir($this->testConfigDir, 0755, true);
+
+    // Capture the test directory in a variable for the closure
+    $testConfigDir = $this->testConfigDir;
+
+    // Mock the path service to use test directory
+    $this->app->bind(KnowledgePathService::class, function () use ($testConfigDir) {
+        $mock = Mockery::mock(KnowledgePathService::class);
+        $mock->shouldReceive('getKnowledgeDirectory')
+            ->andReturn($testConfigDir);
+        $mock->shouldReceive('getDatabasePath')
+            ->andReturn($testConfigDir.'/knowledge.sqlite');
+        $mock->shouldReceive('ensureDirectoryExists')
+            ->andReturnUsing(function ($path) {
+                if (! is_dir($path)) {
+                    mkdir($path, 0755, true);
+                }
+            });
+        $mock->shouldReceive('databaseExists')
+            ->andReturnUsing(function () use ($testConfigDir) {
+                return file_exists($testConfigDir.'/knowledge.sqlite');
+            });
+
+        return $mock;
+    });
+});
+
+afterEach(function () {
+    // Clean up test directory
+    if (isset($this->testConfigDir) && is_dir($this->testConfigDir)) {
+        removeDirectory($this->testConfigDir);
+    }
+});
+
+describe('knowledge:config list', function () {
+    it('lists all config settings when config file exists', function () {
+        // Create config file
+        $configPath = $this->testConfigDir.'/config.json';
+        $config = [
+            'chromadb' => [
+                'enabled' => true,
+                'url' => 'http://localhost:8000',
+            ],
+            'embeddings' => [
+                'url' => 'http://localhost:8001',
+            ],
+        ];
+        file_put_contents($configPath, json_encode($config, JSON_PRETTY_PRINT));
+
+        $this->artisan('knowledge:config')
+            ->expectsOutputToContain('chromadb.enabled: true')
+            ->expectsOutputToContain('chromadb.url: http://localhost:8000')
+            ->expectsOutputToContain('embeddings.url: http://localhost:8001')
+            ->assertSuccessful();
+    });
+
+    it('shows default values when config file does not exist', function () {
+        $this->artisan('knowledge:config')
+            ->expectsOutputToContain('chromadb.enabled: false')
+            ->expectsOutputToContain('chromadb.url: http://localhost:8000')
+            ->expectsOutputToContain('embeddings.url: http://localhost:8001')
+            ->assertSuccessful();
+    });
+
+    it('lists config with list action explicitly', function () {
+        $this->artisan('knowledge:config', ['action' => 'list'])
+            ->expectsOutputToContain('chromadb.enabled')
+            ->assertSuccessful();
+    });
+});
+
+describe('knowledge:config get', function () {
+    it('gets a specific config value', function () {
+        $configPath = $this->testConfigDir.'/config.json';
+        $config = [
+            'chromadb' => [
+                'enabled' => true,
+                'url' => 'http://localhost:8000',
+            ],
+        ];
+        file_put_contents($configPath, json_encode($config));
+
+        $this->artisan('knowledge:config', [
+            'action' => 'get',
+            'key' => 'chromadb.enabled',
+        ])
+            ->expectsOutputToContain('true')
+            ->assertSuccessful();
+    });
+
+    it('gets nested config value', function () {
+        $configPath = $this->testConfigDir.'/config.json';
+        $config = [
+            'chromadb' => [
+                'url' => 'http://custom:9000',
+            ],
+        ];
+        file_put_contents($configPath, json_encode($config));
+
+        $this->artisan('knowledge:config', [
+            'action' => 'get',
+            'key' => 'chromadb.url',
+        ])
+            ->expectsOutputToContain('http://custom:9000')
+            ->assertSuccessful();
+    });
+
+    it('gets default value when key does not exist', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'get',
+            'key' => 'chromadb.enabled',
+        ])
+            ->expectsOutputToContain('false')
+            ->assertSuccessful();
+    });
+
+    it('fails when key is not provided for get action', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'get',
+        ])
+            ->expectsOutputToContain('Key is required for get action')
+            ->assertFailed();
+    });
+
+    it('fails when key is invalid', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'get',
+            'key' => 'invalid.key',
+        ])
+            ->expectsOutputToContain('Invalid configuration key')
+            ->assertFailed();
+    });
+});
+
+describe('knowledge:config set', function () {
+    it('sets a boolean config value to true', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+            'key' => 'chromadb.enabled',
+            'value' => 'true',
+        ])
+            ->expectsOutputToContain('Configuration updated')
+            ->assertSuccessful();
+
+        // Verify the value was set
+        $configPath = $this->testConfigDir.'/config.json';
+        expect(file_exists($configPath))->toBeTrue();
+
+        $config = json_decode(file_get_contents($configPath), true);
+        expect($config['chromadb']['enabled'])->toBe(true);
+    });
+
+    it('sets a boolean config value to false', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+            'key' => 'chromadb.enabled',
+            'value' => 'false',
+        ])
+            ->assertSuccessful();
+
+        $configPath = $this->testConfigDir.'/config.json';
+        $config = json_decode(file_get_contents($configPath), true);
+        expect($config['chromadb']['enabled'])->toBe(false);
+    });
+
+    it('sets a string config value', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+            'key' => 'chromadb.url',
+            'value' => 'http://custom:9000',
+        ])
+            ->assertSuccessful();
+
+        $configPath = $this->testConfigDir.'/config.json';
+        $config = json_decode(file_get_contents($configPath), true);
+        expect($config['chromadb']['url'])->toBe('http://custom:9000');
+    });
+
+    it('sets embeddings url', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+            'key' => 'embeddings.url',
+            'value' => 'http://embeddings:8001',
+        ])
+            ->assertSuccessful();
+
+        $configPath = $this->testConfigDir.'/config.json';
+        $config = json_decode(file_get_contents($configPath), true);
+        expect($config['embeddings']['url'])->toBe('http://embeddings:8001');
+    });
+
+    it('preserves existing config when setting new value', function () {
+        // Set initial value
+        $configPath = $this->testConfigDir.'/config.json';
+        $config = [
+            'chromadb' => [
+                'enabled' => true,
+                'url' => 'http://localhost:8000',
+            ],
+        ];
+        file_put_contents($configPath, json_encode($config));
+
+        // Set new value
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+            'key' => 'embeddings.url',
+            'value' => 'http://new:8001',
+        ])
+            ->assertSuccessful();
+
+        // Verify both values exist
+        $config = json_decode(file_get_contents($configPath), true);
+        expect($config['chromadb']['enabled'])->toBe(true);
+        expect($config['chromadb']['url'])->toBe('http://localhost:8000');
+        expect($config['embeddings']['url'])->toBe('http://new:8001');
+    });
+
+    it('updates existing config value', function () {
+        // Set initial value
+        $configPath = $this->testConfigDir.'/config.json';
+        $config = [
+            'chromadb' => [
+                'enabled' => false,
+            ],
+        ];
+        file_put_contents($configPath, json_encode($config));
+
+        // Update value
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+            'key' => 'chromadb.enabled',
+            'value' => 'true',
+        ])
+            ->assertSuccessful();
+
+        // Verify update
+        $config = json_decode(file_get_contents($configPath), true);
+        expect($config['chromadb']['enabled'])->toBe(true);
+    });
+
+    it('fails when key is not provided for set action', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+        ])
+            ->expectsOutputToContain('Key and value are required for set action')
+            ->assertFailed();
+    });
+
+    it('fails when value is not provided for set action', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+            'key' => 'chromadb.enabled',
+        ])
+            ->expectsOutputToContain('Key and value are required for set action')
+            ->assertFailed();
+    });
+
+    it('fails when key is invalid', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+            'key' => 'invalid.key',
+            'value' => 'value',
+        ])
+            ->expectsOutputToContain('Invalid configuration key')
+            ->assertFailed();
+    });
+
+    it('creates config directory if it does not exist', function () {
+        // Remove test directory
+        removeDirectory($this->testConfigDir);
+
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+            'key' => 'chromadb.enabled',
+            'value' => 'true',
+        ])
+            ->assertSuccessful();
+
+        $configPath = $this->testConfigDir.'/config.json';
+        expect(file_exists($configPath))->toBeTrue();
+    });
+});
+
+describe('knowledge:config invalid action', function () {
+    it('fails with invalid action', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'invalid',
+        ])
+            ->expectsOutputToContain('Invalid action')
+            ->expectsOutputToContain('Valid actions: list, get, set')
+            ->assertFailed();
+    });
+});
+
+describe('knowledge:config edge cases', function () {
+    it('handles invalid JSON in config file', function () {
+        $configPath = $this->testConfigDir.'/config.json';
+        file_put_contents($configPath, 'not valid json {{{');
+
+        // Should use defaults when JSON is invalid
+        $this->artisan('knowledge:config')
+            ->expectsOutputToContain('chromadb.enabled: false')
+            ->assertSuccessful();
+    });
+
+    it('handles non-array JSON in config file', function () {
+        $configPath = $this->testConfigDir.'/config.json';
+        file_put_contents($configPath, '"just a string"');
+
+        // Should use defaults when JSON is not an array
+        $this->artisan('knowledge:config')
+            ->expectsOutputToContain('chromadb.enabled: false')
+            ->assertSuccessful();
+    });
+
+    it('creates new nested path when setting value', function () {
+        // Start with empty config
+        $configPath = $this->testConfigDir.'/config.json';
+        file_put_contents($configPath, '{}');
+
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+            'key' => 'embeddings.url',
+            'value' => 'http://test:8001',
+        ])
+            ->assertSuccessful();
+
+        $config = json_decode(file_get_contents($configPath), true);
+        expect($config['embeddings']['url'])->toBe('http://test:8001');
+    });
+});
+
+describe('knowledge:config validation', function () {
+    it('validates boolean values for chromadb.enabled', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+            'key' => 'chromadb.enabled',
+            'value' => 'invalid',
+        ])
+            ->expectsOutputToContain('must be a boolean')
+            ->assertFailed();
+    });
+
+    it('validates url format for chromadb.url', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+            'key' => 'chromadb.url',
+            'value' => 'not-a-url',
+        ])
+            ->expectsOutputToContain('must be a valid URL')
+            ->assertFailed();
+    });
+
+    it('validates url format for embeddings.url', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+            'key' => 'embeddings.url',
+            'value' => 'invalid-url',
+        ])
+            ->expectsOutputToContain('must be a valid URL')
+            ->assertFailed();
+    });
+
+    it('accepts valid http url', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+            'key' => 'chromadb.url',
+            'value' => 'http://localhost:8000',
+        ])
+            ->assertSuccessful();
+    });
+
+    it('accepts valid https url', function () {
+        $this->artisan('knowledge:config', [
+            'action' => 'set',
+            'key' => 'chromadb.url',
+            'value' => 'https://chromadb.example.com',
+        ])
+            ->assertSuccessful();
+    });
+});


### PR DESCRIPTION
## Summary
Adds a new command to manage ChromaDB and embedding service configuration:
- `knowledge:config list` - Display all config settings
- `knowledge:config get <key>` - Get a specific setting  
- `knowledge:config set <key> <value>` - Update a setting

## Configuration Keys
- `chromadb.enabled` (boolean) - Enable/disable ChromaDB integration
- `chromadb.url` (URL) - ChromaDB server endpoint
- `embeddings.url` (URL) - Embedding service endpoint

## Features
- Validates boolean and URL values
- Sensible defaults for all settings
- Configuration persisted to `~/.knowledge/config.json`
- 27 tests with 100% code coverage

## Test Plan
- [x] All existing tests pass (637 tests)
- [x] Config command tests pass (27 tests, 61 assertions)
- [x] 100% code coverage maintained
- [x] PHPStan level 8 clean
- [x] Pint formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to manage Knowledge configuration with actions for listing, retrieving, and updating settings.
  * Includes validation for configuration values and persistent JSON-based storage.
  * Supports chromadb and embeddings configuration management.

* **Tests**
  * Added comprehensive feature tests for configuration command with edge case and validation coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->