### PR TITLE
feat: add bidirectional sync with --push and --pull flags

### DIFF
--- a/app/Commands/KnowledgeSearchStatusCommand.php
+++ b/app/Commands/KnowledgeSearchStatusCommand.php
@@ -33,8 +33,8 @@ class KnowledgeSearchStatusCommand extends Command
         // Semantic Search Status
         /** @var bool $semanticEnabled */
         $semanticEnabled = config('search.semantic_enabled');
-        /** @var string $embeddingProvider */
-        $embeddingProvider = config('search.embedding_provider');
+        /** @var string|null $embeddingProvider */
+        $embeddingProvider = config('search.embedding_provider') ?: 'none';
 
         $testEmbedding = $embeddingService->generate('test');
         $hasEmbeddingSupport = count($testEmbedding) > 0;

--- a/tests/Feature/SyncCommandTest.php
+++ b/tests/Feature/SyncCommandTest.php
@@ -151,4 +151,326 @@ describe('SyncCommand', function () {
         expect($signature->hasOption('pull'))->toBeTrue()
             ->and($signature->hasOption('push'))->toBeTrue();
     });
+
+    it('handles HTTP error during pull', function () {
+        // Use Mockery for more control
+        $response = m::mock(\Psr\Http\Message\ResponseInterface::class);
+        $response->shouldReceive('getStatusCode')->andReturn(500);
+        $response->shouldReceive('getBody')->andReturn('Internal Server Error');
+
+        $client = m::mock(Client::class);
+        $client->shouldReceive('get')
+            ->once()
+            ->with('/api/knowledge/entries', m::any())
+            ->andReturn($response);
+
+        $this->app->instance(Client::class, $client);
+
+        $this->artisan('sync', ['--pull' => true])
+            ->assertSuccessful();
+
+        // Verify no entries were created due to error
+        expect(Entry::count())->toBe(0);
+    });
+
+    it('handles invalid JSON response during pull', function () {
+        // Mock response without 'data' key
+        $mock = new MockHandler([
+            new Response(200, [], json_encode(['invalid' => 'structure'])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+        $this->app->instance(Client::class, $client);
+
+        $this->artisan('sync', ['--pull' => true])
+            ->assertSuccessful();
+
+        // Verify no entries were created due to invalid response
+        expect(Entry::count())->toBe(0);
+    });
+
+    it('handles network error during pull', function () {
+        // Mock Guzzle exception
+        $mock = new MockHandler([
+            new \GuzzleHttp\Exception\ConnectException(
+                'Connection refused',
+                new \GuzzleHttp\Psr7\Request('GET', '/api/knowledge/entries')
+            ),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+        $this->app->instance(Client::class, $client);
+
+        $this->artisan('sync', ['--pull' => true])
+            ->assertSuccessful();
+
+        // Verify no entries were created due to network error
+        expect(Entry::count())->toBe(0);
+    });
+
+    it('handles HTTP error during push', function () {
+        Entry::create([
+            'title' => 'Test Entry',
+            'content' => 'Test content',
+            'priority' => 'medium',
+            'confidence' => 50,
+            'status' => 'draft',
+        ]);
+
+        // Use Mockery for more control
+        $response = m::mock(\Psr\Http\Message\ResponseInterface::class);
+        $response->shouldReceive('getStatusCode')->andReturn(500);
+        $response->shouldReceive('getBody')->andReturn('Internal Server Error');
+
+        $client = m::mock(Client::class);
+        $client->shouldReceive('post')
+            ->once()
+            ->with('/api/knowledge/sync', m::any())
+            ->andReturn($response);
+
+        $this->app->instance(Client::class, $client);
+
+        $this->artisan('sync', ['--push' => true])
+            ->assertSuccessful();
+
+        // Command completes despite error (returns SUCCESS)
+        expect(Entry::count())->toBe(1);
+    });
+
+    it('handles network error during push', function () {
+        Entry::create([
+            'title' => 'Test Entry',
+            'content' => 'Test content',
+            'priority' => 'medium',
+            'confidence' => 50,
+            'status' => 'draft',
+        ]);
+
+        // Mock Guzzle exception
+        $mock = new MockHandler([
+            new \GuzzleHttp\Exception\ConnectException(
+                'Connection timeout',
+                new \GuzzleHttp\Psr7\Request('POST', '/api/knowledge/sync')
+            ),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+        $this->app->instance(Client::class, $client);
+
+        $this->artisan('sync', ['--push' => true])
+            ->assertSuccessful();
+
+        // Command completes despite error
+        expect(Entry::count())->toBe(1);
+    });
+
+    it('pulls and processes entries from cloud', function () {
+        // Mock successful GET with actual entry data
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                'data' => [
+                    [
+                        'unique_id' => 'test-unique-id-123',
+                        'title' => 'Cloud Entry',
+                        'content' => 'Content from cloud',
+                        'category' => 'test',
+                        'tags' => ['cloud', 'test'],
+                        'module' => 'sync',
+                        'priority' => 'high',
+                        'confidence' => 80,
+                        'source' => 'prefrontal',
+                        'ticket' => 'TICKET-123',
+                        'status' => 'validated',
+                    ],
+                ],
+                'meta' => ['count' => 1, 'synced_at' => now()->toIso8601String()],
+            ])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+        $this->app->instance(Client::class, $client);
+
+        expect(Entry::count())->toBe(0);
+
+        $this->artisan('sync', ['--pull' => true])
+            ->expectsOutput('Pulling entries from cloud...')
+            ->assertSuccessful();
+
+        expect(Entry::count())->toBe(1);
+        $entry = Entry::first();
+        expect($entry->title)->toBe('Cloud Entry')
+            ->and($entry->content)->toBe('Content from cloud')
+            ->and($entry->priority)->toBe('high')
+            ->and($entry->confidence)->toBe(80);
+    });
+
+    it('updates existing entries during pull when title matches', function () {
+        // Create existing local entry
+        Entry::create([
+            'title' => 'Existing Entry',
+            'content' => 'Old content',
+            'priority' => 'low',
+            'confidence' => 30,
+            'status' => 'draft',
+        ]);
+
+        // Mock pull with updated version
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                'data' => [
+                    [
+                        'unique_id' => 'test-unique-id-456',
+                        'title' => 'Existing Entry',
+                        'content' => 'Updated content from cloud',
+                        'category' => 'updated',
+                        'tags' => ['updated'],
+                        'module' => 'sync',
+                        'priority' => 'high',
+                        'confidence' => 90,
+                        'source' => 'prefrontal',
+                        'ticket' => null,
+                        'status' => 'validated',
+                    ],
+                ],
+                'meta' => ['count' => 1, 'synced_at' => now()->toIso8601String()],
+            ])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+        $this->app->instance(Client::class, $client);
+
+        expect(Entry::count())->toBe(1);
+
+        $this->artisan('sync', ['--pull' => true])
+            ->expectsOutput('Pulling entries from cloud...')
+            ->assertSuccessful();
+
+        expect(Entry::count())->toBe(1); // Still 1, updated not created
+        $entry = Entry::first();
+        expect($entry->title)->toBe('Existing Entry')
+            ->and($entry->content)->toBe('Updated content from cloud')
+            ->and($entry->priority)->toBe('high')
+            ->and($entry->confidence)->toBe(90)
+            ->and($entry->status)->toBe('validated');
+    });
+
+    it('skips entries with null unique_id during pull', function () {
+        // Mock response with entry missing unique_id
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                'data' => [
+                    [
+                        // Missing unique_id
+                        'title' => 'Entry Without ID',
+                        'content' => 'Should be skipped',
+                    ],
+                    [
+                        'unique_id' => 'valid-id-789',
+                        'title' => 'Valid Entry',
+                        'content' => 'Should be created',
+                        'priority' => 'medium',
+                        'confidence' => 50,
+                        'status' => 'draft',
+                    ],
+                ],
+                'meta' => ['count' => 2, 'synced_at' => now()->toIso8601String()],
+            ])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+        $this->app->instance(Client::class, $client);
+
+        $this->artisan('sync', ['--pull' => true])
+            ->assertSuccessful();
+
+        // Only the valid entry should be created
+        expect(Entry::count())->toBe(1);
+        expect(Entry::first()->title)->toBe('Valid Entry');
+    });
+
+    it('handles exceptions during entry processing', function () {
+        // Mock response with invalid enum value that will trigger database exception
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                'data' => [
+                    [
+                        'unique_id' => 'invalid-entry-1',
+                        'title' => 'Entry with invalid priority',
+                        'content' => 'This will fail',
+                        'priority' => 'INVALID_PRIORITY_VALUE', // Invalid enum value
+                        'confidence' => 50,
+                        'status' => 'draft',
+                    ],
+                    [
+                        'unique_id' => 'valid-entry-2',
+                        'title' => 'Good Entry',
+                        'content' => 'This should be created',
+                        'priority' => 'medium',
+                        'confidence' => 50,
+                        'status' => 'draft',
+                    ],
+                ],
+                'meta' => ['count' => 2, 'synced_at' => now()->toIso8601String()],
+            ])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+        $this->app->instance(Client::class, $client);
+
+        $this->artisan('sync', ['--pull' => true])
+            ->assertSuccessful();
+
+        // The first entry should fail due to invalid enum, but second should succeed
+        expect(Entry::count())->toBe(1);
+        expect(Entry::first()->title)->toBe('Good Entry');
+    });
+
+    it('creates HTTP client with correct configuration', function () {
+        // Test the createClient method by using reflection
+        $command = new \App\Commands\SyncCommand;
+
+        $reflection = new \ReflectionClass($command);
+        $method = $reflection->getMethod('createClient');
+        $method->setAccessible(true);
+
+        $client = $method->invoke($command);
+
+        expect($client)->toBeInstanceOf(Client::class);
+
+        // Verify the client has the correct configuration
+        $config = $client->getConfig();
+        expect($config['base_uri'])->toBeInstanceOf(\GuzzleHttp\Psr7\Uri::class);
+        expect((string) $config['base_uri'])->toBe('https://prefrontal-cortex.laravel.cloud');
+        expect($config['timeout'])->toBe(30);
+        expect($config['headers']['Accept'])->toBe('application/json');
+        expect($config['headers']['Content-Type'])->toBe('application/json');
+    });
+
+    it('uses createClient when no client is bound to container', function () {
+        // Ensure no Client is bound to the container
+        if (app()->bound(Client::class)) {
+            app()->forgetInstance(Client::class);
+        }
+
+        $command = new \App\Commands\SyncCommand;
+
+        // Use reflection to call getClient()
+        $reflection = new \ReflectionClass($command);
+        $method = $reflection->getMethod('getClient');
+        $method->setAccessible(true);
+
+        // This should trigger the createClient() path (line 82)
+        $client = $method->invoke($command);
+
+        expect($client)->toBeInstanceOf(Client::class);
+        expect((string) $client->getConfig('base_uri'))->toBe('https://prefrontal-cortex.laravel.cloud');
+    });
+
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,4 +4,20 @@ namespace Tests;
 
 use LaravelZero\Framework\Testing\TestCase as BaseTestCase;
 
-abstract class TestCase extends BaseTestCase {}
+abstract class TestCase extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Reset search configuration to test defaults
+        // This ensures tests use stubs for embedding services
+        // but real SQLite FTS for observation search tests
+        config([
+            'search.semantic_enabled' => false,
+            'search.embedding_provider' => null,
+            'search.chromadb.enabled' => false,
+            'search.fts_provider' => 'sqlite', // Use SQLite FTS for tests
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
Implements #47

Add bidirectional sync capabilities to the knowledge CLI with `--push` and `--pull` flags.

## Changes
- **New SyncCommand**: Adds `know sync` command with bidirectional synchronization
- **--pull flag**: Pull entries from prefrontal-cortex cloud only
- **--push flag**: Push local entries to cloud only
- **Default behavior**: Two-way sync (pull then push when no flags specified)
- **Unique ID generation**: SHA256 hash of entry id + title for cloud synchronization
- **Progress indicators**: Progress bars during sync operations
- **Summary tables**: Display sync results (created, updated, failed counts)
- **Error handling**: Graceful handling of network errors
- **Comprehensive tests**: Test coverage for all sync modes

## API Integration
This PR implements the client-side sync logic. The server-side API endpoint `POST /api/knowledge/sync` will be implemented in prefrontal-cortex issue #149.

## Test Plan
- [x] Tests pass for all sync modes
- [x] Token validation works correctly
- [x] Empty database handling works
- [x] Unique ID generation is deterministic
- [x] Command signature includes both flags
- [ ] Integration testing pending API endpoint (#149)

## Usage Examples
```bash
# Pull from cloud only
know sync --pull

# Push to cloud only
know sync --push

# Two-way sync (default)
know sync
```

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cloud synchronization command supporting two-way and single-direction sync (pull/push), with progress tracking and human-readable summaries; validates API token before syncing.

* **Bug Fixes**
  * Ensure embedding provider defaults to "none" when unset so status displays consistently.
  * Test environment now resets search/embedding settings to stable defaults.

* **Tests**
  * Comprehensive tests for sync command: token validation, options, push/pull flows, error handling, and deterministic unique ID generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->