### PR TITLE
fix: handle nested summary in sync API response

### DIFF
--- a/app/Commands/SyncCommand.php
+++ b/app/Commands/SyncCommand.php
@@ -263,9 +263,11 @@ class SyncCommand extends Command
                     $result = json_decode((string) $response->getBody(), true);
                     if (is_array($result)) {
                         $sent += count($chunk);
-                        $created += $result['created'] ?? 0;
-                        $updated += $result['updated'] ?? 0;
-                        $failed += $result['failed'] ?? 0;
+                        // Handle both flat and nested response formats
+                        $summary = $result['summary'] ?? $result;
+                        $created += $summary['created'] ?? 0;
+                        $updated += $summary['updated'] ?? 0;
+                        $failed += $summary['failed'] ?? 0;
                     }
                 } else {
                     $failed += count($chunk);


### PR DESCRIPTION
## Summary
- Fixed sync command not reading created/updated counts from API response
- The prefrontal-cortex API returns counts nested under `summary` key
- CLI was looking at root level, causing 0 counts to display

## Test plan
- [x] Run `know sync` and verify Created/Updated counts now show correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cloud sync response handling to reliably process different response formats and accurately track synchronization metrics across operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->