### PR TITLE
fix: resolve multiple low-hanging fruit issues

### DIFF
--- a/app/Commands/KnowledgeSearchStatusCommand.php
+++ b/app/Commands/KnowledgeSearchStatusCommand.php
@@ -53,18 +53,12 @@ class KnowledgeSearchStatusCommand extends Command
         render(<<<'HTML'
             <div class="mx-2">
                 <div class="px-4 py-2 bg-gray-900 mb-1">
-                    <div class="flex justify-between">
-                        <div class="flex">
-                            <span class="text-green mr-3">✓</span>
-                            <div>
-                                <div class="text-white font-bold">Keyword Search</div>
-                                <div class="text-gray-500">SQL LIKE queries on title and content</div>
-                            </div>
-                        </div>
-                        <div class="text-right">
-                            <div class="text-green font-bold">Enabled</div>
-                        </div>
+                    <div>
+                        <span class="text-green mr-1">✓</span>
+                        <span class="text-white font-bold">Keyword Search</span>
+                        <span class="text-green font-bold ml-1">[Enabled]</span>
                     </div>
+                    <div class="text-gray-500 ml-2">SQL LIKE queries on title and content</div>
                 </div>
             </div>
         HTML);
@@ -77,18 +71,12 @@ class KnowledgeSearchStatusCommand extends Command
         render(<<<HTML
             <div class="mx-2">
                 <div class="px-4 py-2 bg-gray-900 mb-1">
-                    <div class="flex justify-between">
-                        <div class="flex">
-                            <span class="text-{$semanticColor} mr-3">{$semanticIcon}</span>
-                            <div>
-                                <div class="text-white font-bold">Semantic Search</div>
-                                <div class="text-gray-500">Embedding: {$embeddingProvider} · Vector: {$vectorStore}</div>
-                            </div>
-                        </div>
-                        <div class="text-right">
-                            <div class="text-{$semanticColor} font-bold">{$semanticStatus}</div>
-                        </div>
+                    <div>
+                        <span class="text-{$semanticColor} mr-1">{$semanticIcon}</span>
+                        <span class="text-white font-bold">Semantic Search</span>
+                        <span class="text-{$semanticColor} font-bold ml-1">[{$semanticStatus}]</span>
                     </div>
+                    <div class="text-gray-500 ml-2">Embedding: {$embeddingProvider} · Vector: {$vectorStore}</div>
                 </div>
             </div>
         HTML);
@@ -105,13 +93,13 @@ class KnowledgeSearchStatusCommand extends Command
         render(<<<HTML
             <div class="mx-2">
                 <div class="px-4 py-2 bg-gray-900 mb-1">
-                    <div class="flex justify-between">
-                        <div class="text-gray-400">Total Entries</div>
-                        <div class="text-white font-bold">{$totalEntries}</div>
+                    <div>
+                        <span class="text-gray-400">Total Entries:</span>
+                        <span class="text-white font-bold ml-1">{$totalEntries}</span>
                     </div>
-                    <div class="flex justify-between mt-1">
-                        <div class="text-gray-400">Vector Store</div>
-                        <div class="text-cyan-400">{$vectorStore}</div>
+                    <div class="mt-1">
+                        <span class="text-gray-400">Vector Store:</span>
+                        <span class="text-cyan-400 ml-1">{$vectorStore}</span>
                     </div>
                 </div>
             </div>
@@ -133,9 +121,9 @@ class KnowledgeSearchStatusCommand extends Command
         render(<<<'HTML'
             <div class="mx-2">
                 <div class="px-4 py-1 bg-gray-900 mb-1">
-                    <div class="flex justify-between">
-                        <div class="text-gray-400">Keyword Search</div>
-                        <div class="text-cyan-400">./know knowledge:search "query"</div>
+                    <div>
+                        <span class="text-gray-400">Keyword Search:</span>
+                        <span class="text-cyan-400 ml-1">./know knowledge:search "query"</span>
                     </div>
                 </div>
             </div>
@@ -144,9 +132,9 @@ class KnowledgeSearchStatusCommand extends Command
         render(<<<HTML
             <div class="mx-2">
                 <div class="px-4 py-1 bg-gray-900 mb-1">
-                    <div class="flex justify-between">
-                        <div class="text-gray-400">Semantic Search</div>
-                        <div>{$semanticCommand}</div>
+                    <div>
+                        <span class="text-gray-400">Semantic Search:</span>
+                        <span class="ml-1">{$semanticCommand}</span>
                     </div>
                 </div>
             </div>
@@ -155,9 +143,9 @@ class KnowledgeSearchStatusCommand extends Command
         render(<<<'HTML'
             <div class="mx-2">
                 <div class="px-4 py-1 bg-gray-900 mb-1">
-                    <div class="flex justify-between">
-                        <div class="text-gray-400">Index Entries</div>
-                        <div class="text-cyan-400">./know knowledge:index</div>
+                    <div>
+                        <span class="text-gray-400">Index Entries:</span>
+                        <span class="text-cyan-400 ml-1">./know knowledge:index</span>
                     </div>
                 </div>
             </div>

--- a/app/Commands/SynthesizeCommand.php
+++ b/app/Commands/SynthesizeCommand.php
@@ -263,10 +263,10 @@ class SynthesizeCommand extends Command
         $lines = ["**Daily Knowledge Synthesis**\n"];
 
         // Group by category
-        $byCategory = $entries->groupBy(fn (array $e): mixed => $e['category'] ?? 'general');
+        $byCategory = $entries->groupBy(fn (array $e): string => (string) ($e['category'] ?? 'general'));
 
         foreach ($byCategory as $category => $categoryEntries) {
-            $lines[] = "\n### ".ucfirst((string) $category);
+            $lines[] = "\n### ".ucfirst($category);
 
             foreach ($categoryEntries as $entry) {
                 $confidence = $entry['confidence'] ?? 0;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -96,22 +96,7 @@ parameters:
 			path: app/Commands/KnowledgeValidateCommand.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\|bool\\|string\\|null given\\.$#"
-			count: 2
-			path: app/Commands/SyncCommand.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, array\\<string, array\\<string\\>\\|float\\|int\\|string\\|null\\>\\|null given\\.$#"
-			count: 1
-			path: app/Commands/SyncCommand.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, array\\|bool\\|string\\|null given\\.$#"
-			count: 1
-			path: app/Commands/SyncCommand.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, array\\|string\\|true given\\.$#"
 			count: 1
 			path: app/Commands/SyncCommand.php
 
@@ -127,11 +112,6 @@ parameters:
 
 		-
 			message: "#^Offset 'updated_at' on array\\{id\\: int\\|string, title\\: string, content\\: string, tags\\: array\\<string\\>, category\\: string\\|null, module\\: string\\|null, priority\\: string\\|null, status\\: string\\|null, \\.\\.\\.\\} in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: app/Commands/SynthesizeCommand.php
-
-		-
-			message: "#^Unable to resolve the template type TGroupKey in call to method Illuminate\\\\Support\\\\Collection\\<int,array\\<string, mixed\\>\\>\\:\\:groupBy\\(\\)$#"
 			count: 1
 			path: app/Commands/SynthesizeCommand.php
 

--- a/tests/Feature/AppServiceProviderTest.php
+++ b/tests/Feature/AppServiceProviderTest.php
@@ -103,6 +103,271 @@ describe('AppServiceProvider', function (): void {
     });
 });
 
+describe('AppServiceProvider user config loading', function (): void {
+    beforeEach(function (): void {
+        // Create a temporary directory for testing user config
+        $this->testConfigDir = sys_get_temp_dir().'/knowledge-provider-test-'.uniqid();
+        mkdir($this->testConfigDir, 0755, true);
+    });
+
+    afterEach(function (): void {
+        // Clean up test directory
+        if (property_exists($this, 'testConfigDir') && $this->testConfigDir !== null && is_dir($this->testConfigDir)) {
+            removeDirectory($this->testConfigDir);
+        }
+    });
+
+    it('loads qdrant url and parses host and port', function (): void {
+        $configPath = $this->testConfigDir.'/config.json';
+        $config = [
+            'qdrant' => [
+                'url' => 'http://custom-host:7333',
+            ],
+        ];
+        file_put_contents($configPath, json_encode($config));
+
+        // Mock path service to return our test directory
+        $testConfigDir = $this->testConfigDir;
+        $mock = Mockery::mock(KnowledgePathService::class);
+        $mock->shouldReceive('getKnowledgeDirectory')
+            ->andReturn($testConfigDir);
+
+        app()->instance(KnowledgePathService::class, $mock);
+
+        // Call boot to load user config
+        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider->boot();
+
+        expect(config('search.qdrant.host'))->toBe('custom-host');
+        expect(config('search.qdrant.port'))->toBe(7333);
+        expect(config('search.qdrant.secure'))->toBeFalse();
+    });
+
+    it('loads qdrant url with https and sets secure to true', function (): void {
+        $configPath = $this->testConfigDir.'/config.json';
+        $config = [
+            'qdrant' => [
+                'url' => 'https://secure-host:443',
+            ],
+        ];
+        file_put_contents($configPath, json_encode($config));
+
+        $testConfigDir = $this->testConfigDir;
+        $mock = Mockery::mock(KnowledgePathService::class);
+        $mock->shouldReceive('getKnowledgeDirectory')
+            ->andReturn($testConfigDir);
+
+        app()->instance(KnowledgePathService::class, $mock);
+
+        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider->boot();
+
+        expect(config('search.qdrant.host'))->toBe('secure-host');
+        expect(config('search.qdrant.port'))->toBe(443);
+        expect(config('search.qdrant.secure'))->toBeTrue();
+    });
+
+    it('loads qdrant collection', function (): void {
+        $configPath = $this->testConfigDir.'/config.json';
+        $config = [
+            'qdrant' => [
+                'collection' => 'my-custom-collection',
+            ],
+        ];
+        file_put_contents($configPath, json_encode($config));
+
+        $testConfigDir = $this->testConfigDir;
+        $mock = Mockery::mock(KnowledgePathService::class);
+        $mock->shouldReceive('getKnowledgeDirectory')
+            ->andReturn($testConfigDir);
+
+        app()->instance(KnowledgePathService::class, $mock);
+
+        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider->boot();
+
+        expect(config('search.qdrant.collection'))->toBe('my-custom-collection');
+    });
+
+    it('loads embeddings url into embedding_server config', function (): void {
+        $configPath = $this->testConfigDir.'/config.json';
+        $config = [
+            'embeddings' => [
+                'url' => 'http://custom-embeddings:9001',
+            ],
+        ];
+        file_put_contents($configPath, json_encode($config));
+
+        $testConfigDir = $this->testConfigDir;
+        $mock = Mockery::mock(KnowledgePathService::class);
+        $mock->shouldReceive('getKnowledgeDirectory')
+            ->andReturn($testConfigDir);
+
+        app()->instance(KnowledgePathService::class, $mock);
+
+        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider->boot();
+
+        expect(config('search.qdrant.embedding_server'))->toBe('http://custom-embeddings:9001');
+    });
+
+    it('loads all config values together', function (): void {
+        $configPath = $this->testConfigDir.'/config.json';
+        $config = [
+            'qdrant' => [
+                'url' => 'http://qdrant-server:6334',
+                'collection' => 'test-knowledge',
+            ],
+            'embeddings' => [
+                'url' => 'http://embedding-server:8002',
+            ],
+        ];
+        file_put_contents($configPath, json_encode($config));
+
+        $testConfigDir = $this->testConfigDir;
+        $mock = Mockery::mock(KnowledgePathService::class);
+        $mock->shouldReceive('getKnowledgeDirectory')
+            ->andReturn($testConfigDir);
+
+        app()->instance(KnowledgePathService::class, $mock);
+
+        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider->boot();
+
+        expect(config('search.qdrant.host'))->toBe('qdrant-server');
+        expect(config('search.qdrant.port'))->toBe(6334);
+        expect(config('search.qdrant.collection'))->toBe('test-knowledge');
+        expect(config('search.qdrant.embedding_server'))->toBe('http://embedding-server:8002');
+    });
+
+    it('does not modify config when config file does not exist', function (): void {
+        // Set some default values
+        config([
+            'search.qdrant.host' => 'default-host',
+            'search.qdrant.port' => 6333,
+        ]);
+
+        $testConfigDir = $this->testConfigDir;
+        $mock = Mockery::mock(KnowledgePathService::class);
+        $mock->shouldReceive('getKnowledgeDirectory')
+            ->andReturn($testConfigDir);
+
+        app()->instance(KnowledgePathService::class, $mock);
+
+        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider->boot();
+
+        // Config should remain unchanged
+        expect(config('search.qdrant.host'))->toBe('default-host');
+        expect(config('search.qdrant.port'))->toBe(6333);
+    });
+
+    it('handles invalid JSON in config file gracefully', function (): void {
+        $configPath = $this->testConfigDir.'/config.json';
+        file_put_contents($configPath, 'not valid json {{{');
+
+        // Set some default values
+        config([
+            'search.qdrant.host' => 'default-host',
+        ]);
+
+        $testConfigDir = $this->testConfigDir;
+        $mock = Mockery::mock(KnowledgePathService::class);
+        $mock->shouldReceive('getKnowledgeDirectory')
+            ->andReturn($testConfigDir);
+
+        app()->instance(KnowledgePathService::class, $mock);
+
+        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider->boot();
+
+        // Config should remain unchanged
+        expect(config('search.qdrant.host'))->toBe('default-host');
+    });
+
+    it('handles non-array JSON in config file gracefully', function (): void {
+        $configPath = $this->testConfigDir.'/config.json';
+        file_put_contents($configPath, '"just a string"');
+
+        config([
+            'search.qdrant.host' => 'default-host',
+        ]);
+
+        $testConfigDir = $this->testConfigDir;
+        $mock = Mockery::mock(KnowledgePathService::class);
+        $mock->shouldReceive('getKnowledgeDirectory')
+            ->andReturn($testConfigDir);
+
+        app()->instance(KnowledgePathService::class, $mock);
+
+        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider->boot();
+
+        expect(config('search.qdrant.host'))->toBe('default-host');
+    });
+
+    it('handles non-string values in config gracefully', function (): void {
+        $configPath = $this->testConfigDir.'/config.json';
+        $config = [
+            'qdrant' => [
+                'url' => 12345, // Not a string
+                'collection' => ['not', 'a', 'string'],
+            ],
+            'embeddings' => [
+                'url' => null,
+            ],
+        ];
+        file_put_contents($configPath, json_encode($config));
+
+        config([
+            'search.qdrant.host' => 'default-host',
+            'search.qdrant.collection' => 'default-collection',
+        ]);
+
+        $testConfigDir = $this->testConfigDir;
+        $mock = Mockery::mock(KnowledgePathService::class);
+        $mock->shouldReceive('getKnowledgeDirectory')
+            ->andReturn($testConfigDir);
+
+        app()->instance(KnowledgePathService::class, $mock);
+
+        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider->boot();
+
+        // Config should remain unchanged since values are not strings
+        expect(config('search.qdrant.host'))->toBe('default-host');
+        expect(config('search.qdrant.collection'))->toBe('default-collection');
+    });
+
+    it('handles url without port', function (): void {
+        $configPath = $this->testConfigDir.'/config.json';
+        $config = [
+            'qdrant' => [
+                'url' => 'http://qdrant-server',
+            ],
+        ];
+        file_put_contents($configPath, json_encode($config));
+
+        config([
+            'search.qdrant.port' => 6333,
+        ]);
+
+        $testConfigDir = $this->testConfigDir;
+        $mock = Mockery::mock(KnowledgePathService::class);
+        $mock->shouldReceive('getKnowledgeDirectory')
+            ->andReturn($testConfigDir);
+
+        app()->instance(KnowledgePathService::class, $mock);
+
+        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider->boot();
+
+        expect(config('search.qdrant.host'))->toBe('qdrant-server');
+        // Port should remain unchanged since it's not in the URL
+        expect(config('search.qdrant.port'))->toBe(6333);
+    });
+});
+
 afterEach(function (): void {
     Mockery::close();
 });

--- a/tests/Feature/Commands/SyncCommandTest.php
+++ b/tests/Feature/Commands/SyncCommandTest.php
@@ -1,0 +1,418 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\QdrantService;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+
+beforeEach(function (): void {
+    $this->qdrantMock = Mockery::mock(QdrantService::class);
+    $this->app->instance(QdrantService::class, $this->qdrantMock);
+
+    // Set up config for prefrontal API
+    config(['services.prefrontal.token' => 'test-token']);
+    config(['services.prefrontal.url' => 'http://test-api.local']);
+});
+
+describe('SyncCommand --delete option', function (): void {
+    it('fails when --delete is used without --push', function (): void {
+        $this->artisan('sync', ['--delete' => true])
+            ->assertFailed()
+            ->expectsOutput('The --delete option requires --push to be specified.');
+    });
+
+    it('deletes orphaned cloud entries when --delete is used with --push', function (): void {
+        // Local entries
+        $localEntries = collect([
+            [
+                'id' => 'local-1',
+                'title' => 'Local Entry 1',
+                'content' => 'Content 1',
+                'category' => 'testing',
+                'tags' => [],
+                'module' => null,
+                'priority' => 'medium',
+                'status' => 'draft',
+                'confidence' => 50,
+            ],
+        ]);
+
+        // Cloud entries - one matches local, one is orphaned
+        $cloudEntries = [
+            'data' => [
+                [
+                    'id' => 1,
+                    'unique_id' => hash('sha256', 'local-1-Local Entry 1'),
+                    'title' => 'Local Entry 1',
+                    'content' => 'Content 1',
+                ],
+                [
+                    'id' => 2,
+                    'unique_id' => hash('sha256', 'orphan-id-Orphaned Entry'),
+                    'title' => 'Orphaned Entry',
+                    'content' => 'This entry does not exist locally',
+                ],
+            ],
+        ];
+
+        // Mock Qdrant to return local entries
+        $this->qdrantMock->shouldReceive('search')
+            ->with('', [], 10000)
+            ->andReturn($localEntries);
+
+        // Create mock HTTP responses
+        $mockHandler = new MockHandler([
+            // Push response
+            new Response(200, [], json_encode(['summary' => ['created' => 0, 'updated' => 1, 'failed' => 0]])),
+            // Get cloud entries for delete comparison
+            new Response(200, [], json_encode($cloudEntries)),
+            // Delete orphaned entry response
+            new Response(204),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+
+        $this->app->instance(Client::class, $mockClient);
+
+        $this->artisan('sync', ['--push' => true, '--delete' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Pushing local entries to cloud')
+            ->expectsOutputToContain('Deleting cloud entries not present locally')
+            ->expectsOutputToContain('1 orphaned cloud entries to delete');
+    });
+
+    it('handles case when no cloud entries exist', function (): void {
+        // Local entries
+        $localEntries = collect([
+            [
+                'id' => 'local-1',
+                'title' => 'Local Entry 1',
+                'content' => 'Content 1',
+                'category' => 'testing',
+                'tags' => [],
+                'module' => null,
+                'priority' => 'medium',
+                'status' => 'draft',
+                'confidence' => 50,
+            ],
+        ]);
+
+        $this->qdrantMock->shouldReceive('search')
+            ->with('', [], 10000)
+            ->andReturn($localEntries);
+
+        // Cloud has no entries with unique_id/id
+        $cloudEntries = [
+            'data' => [],
+        ];
+
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode(['summary' => ['created' => 1, 'updated' => 0, 'failed' => 0]])),
+            new Response(200, [], json_encode($cloudEntries)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+
+        $this->app->instance(Client::class, $mockClient);
+
+        $this->artisan('sync', ['--push' => true, '--delete' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('No cloud entries to process');
+    });
+
+    it('handles case when all cloud entries exist locally', function (): void {
+        // Local entries
+        $localEntries = collect([
+            [
+                'id' => 'local-1',
+                'title' => 'Entry 1',
+                'content' => 'Content 1',
+                'category' => 'testing',
+                'tags' => [],
+                'module' => null,
+                'priority' => 'medium',
+                'status' => 'draft',
+                'confidence' => 50,
+            ],
+        ]);
+
+        $this->qdrantMock->shouldReceive('search')
+            ->with('', [], 10000)
+            ->andReturn($localEntries);
+
+        // Cloud entry matches local
+        $cloudEntries = [
+            'data' => [
+                [
+                    'id' => 1,
+                    'unique_id' => hash('sha256', 'local-1-Entry 1'),
+                    'title' => 'Entry 1',
+                    'content' => 'Content 1',
+                ],
+            ],
+        ];
+
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode(['summary' => ['created' => 0, 'updated' => 1, 'failed' => 0]])),
+            new Response(200, [], json_encode($cloudEntries)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+
+        $this->app->instance(Client::class, $mockClient);
+
+        $this->artisan('sync', ['--push' => true, '--delete' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('No orphaned cloud entries to delete');
+    });
+
+    it('handles invalid cloud API response for delete', function (): void {
+        $localEntries = collect([
+            [
+                'id' => 'local-1',
+                'title' => 'Entry 1',
+                'content' => 'Content 1',
+                'category' => 'testing',
+                'tags' => [],
+                'module' => null,
+                'priority' => 'medium',
+                'status' => 'draft',
+                'confidence' => 50,
+            ],
+        ]);
+
+        $this->qdrantMock->shouldReceive('search')
+            ->with('', [], 10000)
+            ->andReturn($localEntries);
+
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode(['summary' => ['created' => 0, 'updated' => 1, 'failed' => 0]])),
+            new Response(200, [], json_encode(['invalid' => 'response'])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+
+        $this->app->instance(Client::class, $mockClient);
+
+        $this->artisan('sync', ['--push' => true, '--delete' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Invalid response from cloud API');
+    });
+});
+
+describe('SyncCommand configuration validation', function (): void {
+    it('fails when API token is not set', function (): void {
+        config(['services.prefrontal.token' => '']);
+
+        $this->artisan('sync')
+            ->assertFailed()
+            ->expectsOutput('PREFRONTAL_API_TOKEN environment variable is not set.');
+    });
+
+    it('fails when API URL is not set', function (): void {
+        config(['services.prefrontal.url' => '']);
+
+        $this->artisan('sync')
+            ->assertFailed()
+            ->expectsOutput('PREFRONTAL_API_URL environment variable is not set.');
+    });
+});
+
+describe('SyncCommand --push option', function (): void {
+    it('pushes local entries to cloud', function (): void {
+        $localEntries = collect([
+            [
+                'id' => 'local-1',
+                'title' => 'Entry 1',
+                'content' => 'Content 1',
+                'category' => 'testing',
+                'tags' => ['tag1'],
+                'module' => 'TestModule',
+                'priority' => 'high',
+                'status' => 'validated',
+                'confidence' => 90,
+            ],
+        ]);
+
+        $this->qdrantMock->shouldReceive('search')
+            ->with('', [], 10000)
+            ->andReturn($localEntries);
+
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode(['summary' => ['created' => 1, 'updated' => 0, 'failed' => 0]])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+
+        $this->app->instance(Client::class, $mockClient);
+
+        $this->artisan('sync', ['--push' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Pushing local entries to cloud')
+            ->expectsOutputToContain('Push Summary');
+    });
+
+    it('handles empty local entries', function (): void {
+        $this->qdrantMock->shouldReceive('search')
+            ->with('', [], 10000)
+            ->andReturn(collect());
+
+        $this->artisan('sync', ['--push' => true])
+            ->assertSuccessful()
+            ->expectsOutput('No local entries to push.');
+    });
+});
+
+describe('SyncCommand --pull option', function (): void {
+    it('pulls entries from cloud', function (): void {
+        $cloudEntries = [
+            'data' => [
+                [
+                    'unique_id' => 'cloud-unique-1',
+                    'title' => 'Cloud Entry 1',
+                    'content' => 'Cloud content',
+                    'category' => 'architecture',
+                    'tags' => [],
+                    'module' => null,
+                    'priority' => 'medium',
+                    'confidence' => 75,
+                    'status' => 'draft',
+                ],
+            ],
+        ];
+
+        $this->qdrantMock->shouldReceive('search')
+            ->with('Cloud Entry 1', [], 1)
+            ->andReturn(collect());
+
+        $this->qdrantMock->shouldReceive('upsert')
+            ->once()
+            ->andReturn(true);
+
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode($cloudEntries)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+
+        $this->app->instance(Client::class, $mockClient);
+
+        $this->artisan('sync', ['--pull' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Pulling entries from cloud')
+            ->expectsOutputToContain('Pull Summary');
+    });
+
+    it('handles invalid cloud response on pull', function (): void {
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode(['invalid' => 'response'])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+
+        $this->app->instance(Client::class, $mockClient);
+
+        $this->artisan('sync', ['--pull' => true])
+            ->assertSuccessful()
+            ->expectsOutput('Invalid response from cloud API.');
+    });
+
+    it('skips entries without unique_id', function (): void {
+        $cloudEntries = [
+            'data' => [
+                [
+                    'title' => 'Entry without unique_id',
+                    'content' => 'Content',
+                ],
+            ],
+        ];
+
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode($cloudEntries)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+
+        $this->app->instance(Client::class, $mockClient);
+
+        $this->artisan('sync', ['--pull' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Pull Summary');
+    });
+});
+
+describe('SyncCommand two-way sync', function (): void {
+    it('performs pull then push when no options specified', function (): void {
+        // Cloud entries for pull
+        $cloudEntries = [
+            'data' => [
+                [
+                    'unique_id' => 'cloud-1',
+                    'title' => 'Cloud Entry',
+                    'content' => 'Content',
+                    'category' => 'testing',
+                    'tags' => [],
+                    'module' => null,
+                    'priority' => 'medium',
+                    'confidence' => 50,
+                    'status' => 'draft',
+                ],
+            ],
+        ];
+
+        // Local entries for push
+        $localEntries = collect([
+            [
+                'id' => 'local-1',
+                'title' => 'Local Entry',
+                'content' => 'Content',
+                'category' => 'testing',
+                'tags' => [],
+                'module' => null,
+                'priority' => 'medium',
+                'status' => 'draft',
+                'confidence' => 50,
+            ],
+        ]);
+
+        $this->qdrantMock->shouldReceive('search')
+            ->with('Cloud Entry', [], 1)
+            ->andReturn(collect());
+
+        $this->qdrantMock->shouldReceive('upsert')
+            ->once()
+            ->andReturn(true);
+
+        $this->qdrantMock->shouldReceive('search')
+            ->with('', [], 10000)
+            ->andReturn($localEntries);
+
+        $mockHandler = new MockHandler([
+            // Pull response
+            new Response(200, [], json_encode($cloudEntries)),
+            // Push response
+            new Response(200, [], json_encode(['summary' => ['created' => 1, 'updated' => 0, 'failed' => 0]])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+
+        $this->app->instance(Client::class, $mockClient);
+
+        $this->artisan('sync')
+            ->assertSuccessful()
+            ->expectsOutputToContain('Starting two-way sync')
+            ->expectsOutputToContain('Sync Summary');
+    });
+});


### PR DESCRIPTION
## Summary

Closes #92, #84, #57

### #92 - Config mismatch fixed
`know config set` now properly affects runtime configuration by loading `~/.knowledge/config.json` at boot and merging into Laravel config.

### #84 - Termwind styling fixed
Removed unsupported flexbox CSS classes (`flex`, `justify-between`) and replaced with supported inline spans and margin classes.

### #57 - Sync deletions added
New `--delete` flag for sync command:
```bash
./know sync --push --delete  # Removes orphaned cloud entries
```

## Test plan

- [x] 629 tests passing
- [x] PHPStan level 8 clean
- [x] 99.6% coverage maintained
- [x] 36 new tests added

## Issues closed

- Closes #92
- Closes #84
- Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--delete` flag to sync command for removing orphaned cloud entries when pushing
  * Introduced user configuration file support via `~/.knowledge/config.json` for customizing Qdrant and embedding settings

* **Improvements**
  * Refined knowledge search status display layout for better readability
  * Enhanced internal type handling for entry grouping operations

* **Testing**
  * Added comprehensive test coverage for sync operations and configuration loading

<!-- end of auto-generated comment: release notes by coderabbit.ai -->