### PR TITLE
feat: add context command for semantic session context loading

### DIFF
--- a/app/Commands/ContextCommand.php
+++ b/app/Commands/ContextCommand.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands;
+
+use App\Services\GitContextService;
+use App\Services\QdrantService;
+use LaravelZero\Framework\Commands\Command;
+
+class ContextCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'context
+                            {--project= : Project namespace (auto-detected from git if omitted)}
+                            {--categories= : Comma-separated categories to include (e.g. architecture,patterns,decisions,gotchas)}
+                            {--max-tokens=4000 : Maximum approximate token count for output}
+                            {--limit=50 : Maximum entries to fetch from Qdrant}
+                            {--no-usage : Do not increment usage_count for accessed entries}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Load semantic session context for AI consumption';
+
+    private const CHARS_PER_TOKEN = 4;
+
+    /**
+     * Default category display order.
+     *
+     * @var array<int, string>
+     */
+    private const CATEGORY_ORDER = [
+        'architecture',
+        'patterns',
+        'decisions',
+        'gotchas',
+        'debugging',
+        'testing',
+        'deployment',
+        'security',
+    ];
+
+    public function handle(QdrantService $qdrant, GitContextService $git): int
+    {
+        $project = $this->resolveProject($git);
+        $categories = $this->resolveCategories();
+        $maxTokens = (int) $this->option('max-tokens');
+        $limit = (int) $this->option('limit');
+        $trackUsage = $this->option('no-usage') !== true;
+
+        $entries = $this->fetchEntries($qdrant, $categories, $limit, $project);
+
+        if ($entries === []) {
+            $this->line('No context entries found.');
+
+            return self::SUCCESS;
+        }
+
+        $ranked = $this->rankEntries($entries);
+        $grouped = $this->groupByCategory($ranked);
+        $markdown = $this->formatMarkdown($grouped, $maxTokens, $project);
+
+        foreach (explode("\n", $markdown) as $markdownLine) {
+            $this->line($markdownLine);
+        }
+
+        if ($trackUsage) {
+            $this->incrementUsageCounts($qdrant, $ranked, $maxTokens, $project);
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function resolveProject(GitContextService $git): string
+    {
+        $explicit = $this->option('project');
+
+        if (is_string($explicit) && $explicit !== '') {
+            return $explicit;
+        }
+
+        if ($git->isGitRepository()) {
+            $repoPath = $git->getRepositoryPath();
+
+            if (is_string($repoPath) && $repoPath !== '') {
+                return basename($repoPath);
+            }
+        }
+
+        return 'default';
+    }
+
+    /**
+     * @return array<int, string>|null
+     */
+    private function resolveCategories(): ?array
+    {
+        $raw = $this->option('categories');
+
+        if (! is_string($raw) || $raw === '') {
+            return null;
+        }
+
+        return array_map('trim', explode(',', $raw));
+    }
+
+    /**
+     * @param  array<int, string>|null  $categories
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchEntries(QdrantService $qdrant, ?array $categories, int $limit, string $project): array
+    {
+        if ($categories !== null) {
+            $entries = [];
+            $perCategory = max(1, intdiv($limit, count($categories)));
+
+            foreach ($categories as $category) {
+                $results = $qdrant->scroll(
+                    ['category' => $category],
+                    $perCategory,
+                    $project
+                );
+
+                foreach ($results->all() as $entry) {
+                    $entries[] = $entry;
+                }
+            }
+
+            return $entries;
+        }
+
+        return $qdrant->scroll([], $limit, $project)->all();
+    }
+
+    /**
+     * Rank entries by recency and usage_count.
+     *
+     * Score = (usage_count * 2) + recency_days_inverse
+     *
+     * @param  array<int, array<string, mixed>>  $entries
+     * @return array<int, array<string, mixed>>
+     */
+    private function rankEntries(array $entries): array
+    {
+        $now = time();
+
+        usort($entries, function (array $a, array $b) use ($now): int {
+            return $this->entryScore($b, $now) <=> $this->entryScore($a, $now);
+        });
+
+        return $entries;
+    }
+
+    /**
+     * @param  array<string, mixed>  $entry
+     */
+    private function entryScore(array $entry, int $now): float
+    {
+        $usageCount = (int) ($entry['usage_count'] ?? 0);
+        $updatedAt = $entry['updated_at'] ?? '';
+
+        $timestamp = is_string($updatedAt) && $updatedAt !== ''
+            ? strtotime($updatedAt)
+            : $now;
+
+        if ($timestamp === false) {
+            $timestamp = $now;
+        }
+
+        $daysAgo = max(1, (int) (($now - $timestamp) / 86400));
+        $recencyScore = 100.0 / $daysAgo;
+
+        return ($usageCount * 2.0) + $recencyScore;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $entries
+     * @return array<string, array<int, array<string, mixed>>>
+     */
+    private function groupByCategory(array $entries): array
+    {
+        $grouped = [];
+
+        foreach ($entries as $entry) {
+            $category = is_string($entry['category'] ?? null) && ($entry['category'] ?? '') !== ''
+                ? $entry['category']
+                : 'uncategorized';
+
+            $grouped[$category][] = $entry;
+        }
+
+        // Sort categories by defined order
+        $ordered = [];
+
+        foreach (self::CATEGORY_ORDER as $cat) {
+            if (isset($grouped[$cat])) {
+                $ordered[$cat] = $grouped[$cat];
+                unset($grouped[$cat]);
+            }
+        }
+
+        // Append remaining categories alphabetically
+        ksort($grouped);
+
+        return array_merge($ordered, $grouped);
+    }
+
+    /**
+     * @param  array<string, array<int, array<string, mixed>>>  $grouped
+     */
+    private function formatMarkdown(array $grouped, int $maxTokens, string $project): string
+    {
+        $maxChars = $maxTokens * self::CHARS_PER_TOKEN;
+        $lines = [];
+        $charCount = 0;
+
+        $header = "# Session Context: {$project}";
+        $lines[] = $header;
+        $lines[] = '';
+        $charCount += strlen($header) + 1;
+
+        foreach ($grouped as $category => $entries) {
+            $catHeader = '## '.ucfirst($category);
+            $catHeaderLen = strlen($catHeader) + 2;
+
+            if ($charCount + $catHeaderLen > $maxChars) {
+                break;
+            }
+
+            $lines[] = $catHeader;
+            $lines[] = '';
+            $charCount += $catHeaderLen;
+
+            foreach ($entries as $entry) {
+                $block = $this->formatEntry($entry);
+                $blockLen = strlen($block) + 1;
+
+                if ($charCount + $blockLen > $maxChars) {
+                    break 2;
+                }
+
+                $lines[] = $block;
+                $charCount += $blockLen;
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param  array<string, mixed>  $entry
+     */
+    private function formatEntry(array $entry): string
+    {
+        $title = $entry['title'] ?? 'Untitled';
+        $content = $entry['content'] ?? '';
+        $tags = $entry['tags'] ?? [];
+        $priority = $entry['priority'] ?? 'medium';
+        $confidence = $entry['confidence'] ?? 0;
+
+        $lines = [];
+        $lines[] = "### {$title}";
+        $lines[] = '';
+
+        $lines[] = "Priority: {$priority}";
+        $lines[] = "Confidence: {$confidence}%";
+
+        if (is_array($tags) && $tags !== []) {
+            $lines[] = 'Tags: '.implode(', ', $tags);
+        }
+
+        $lines[] = '';
+        $lines[] = $content;
+        $lines[] = '';
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Increment usage_count for entries that fit within the token budget.
+     *
+     * @param  array<int, array<string, mixed>>  $ranked
+     */
+    private function incrementUsageCounts(QdrantService $qdrant, array $ranked, int $maxTokens, string $project): void
+    {
+        $maxChars = $maxTokens * self::CHARS_PER_TOKEN;
+        $charCount = 0;
+
+        foreach ($ranked as $entry) {
+            $block = $this->formatEntry($entry);
+            $blockLen = strlen($block);
+
+            if ($charCount + $blockLen > $maxChars) {
+                break;
+            }
+
+            $charCount += $blockLen;
+
+            $id = $entry['id'] ?? null;
+
+            if ($id !== null) {
+                $qdrant->incrementUsage($id, $project);
+            }
+        }
+    }
+}

--- a/tests/Feature/ContextCommandTest.php
+++ b/tests/Feature/ContextCommandTest.php
@@ -1,0 +1,424 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\GitContextService;
+use App\Services\QdrantService;
+
+describe('ContextCommand', function (): void {
+    beforeEach(function (): void {
+        $this->qdrantService = mock(QdrantService::class);
+        $this->gitService = mock(GitContextService::class);
+
+        app()->instance(QdrantService::class, $this->qdrantService);
+        app()->instance(GitContextService::class, $this->gitService);
+
+        $this->gitService->shouldReceive('isGitRepository')->andReturn(true)->byDefault();
+        $this->gitService->shouldReceive('getRepositoryPath')->andReturn('/home/user/my-project')->byDefault();
+    });
+
+    it('outputs markdown context grouped by category', function (): void {
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->with([], 50, 'my-project')
+            ->andReturn(collect([
+                [
+                    'id' => 'uuid-1',
+                    'title' => 'Service Layer Pattern',
+                    'content' => 'Use service classes for business logic.',
+                    'tags' => ['architecture', 'services'],
+                    'category' => 'architecture',
+                    'priority' => 'high',
+                    'confidence' => 90,
+                    'usage_count' => 5,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+                [
+                    'id' => 'uuid-2',
+                    'title' => 'N+1 Query Gotcha',
+                    'content' => 'Always eager load relationships.',
+                    'tags' => ['performance'],
+                    'category' => 'gotchas',
+                    'priority' => 'critical',
+                    'confidence' => 95,
+                    'usage_count' => 3,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+            ]));
+
+        $this->qdrantService->shouldReceive('incrementUsage')->twice();
+
+        $this->artisan('context')
+            ->assertSuccessful()
+            ->expectsOutputToContain('# Session Context: my-project')
+            ->expectsOutputToContain('## Architecture')
+            ->expectsOutputToContain('### Service Layer Pattern')
+            ->expectsOutputToContain('## Gotchas')
+            ->expectsOutputToContain('### N+1 Query Gotcha');
+    });
+
+    it('shows no context message when empty', function (): void {
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->andReturn(collect([]));
+
+        $this->artisan('context')
+            ->assertSuccessful()
+            ->expectsOutput('No context entries found.');
+    });
+
+    it('auto-detects project from git repo', function (): void {
+        $this->gitService->shouldReceive('isGitRepository')->andReturn(true);
+        $this->gitService->shouldReceive('getRepositoryPath')->andReturn('/home/user/knowledge');
+
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->with([], 50, 'knowledge')
+            ->andReturn(collect([]));
+
+        $this->artisan('context')
+            ->assertSuccessful();
+    });
+
+    it('falls back to default when not in git repo', function (): void {
+        $this->gitService->shouldReceive('isGitRepository')->andReturn(false);
+
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->with([], 50, 'default')
+            ->andReturn(collect([]));
+
+        $this->artisan('context')
+            ->assertSuccessful();
+    });
+
+    it('uses explicit project flag over auto-detection', function (): void {
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->with([], 50, 'custom-project')
+            ->andReturn(collect([]));
+
+        $this->artisan('context', ['--project' => 'custom-project'])
+            ->assertSuccessful();
+    });
+
+    it('filters by categories flag', function (): void {
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->with(['category' => 'architecture'], 25, 'my-project')
+            ->andReturn(collect([
+                [
+                    'id' => 'uuid-1',
+                    'title' => 'Arch Entry',
+                    'content' => 'Architecture content.',
+                    'tags' => [],
+                    'category' => 'architecture',
+                    'priority' => 'high',
+                    'confidence' => 90,
+                    'usage_count' => 1,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+            ]));
+
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->with(['category' => 'decisions'], 25, 'my-project')
+            ->andReturn(collect([
+                [
+                    'id' => 'uuid-2',
+                    'title' => 'Decision Entry',
+                    'content' => 'Decision content.',
+                    'tags' => [],
+                    'category' => 'decisions',
+                    'priority' => 'medium',
+                    'confidence' => 80,
+                    'usage_count' => 0,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+            ]));
+
+        $this->qdrantService->shouldReceive('incrementUsage')->twice();
+
+        $this->artisan('context', ['--categories' => 'architecture,decisions'])
+            ->assertSuccessful()
+            ->expectsOutputToContain('## Architecture')
+            ->expectsOutputToContain('## Decisions');
+    });
+
+    it('respects max-tokens flag', function (): void {
+        // Generate entries that would exceed a tiny token budget
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->andReturn(collect([
+                [
+                    'id' => 'uuid-1',
+                    'title' => 'First Entry',
+                    'content' => str_repeat('A', 200),
+                    'tags' => [],
+                    'category' => 'architecture',
+                    'priority' => 'high',
+                    'confidence' => 90,
+                    'usage_count' => 10,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+                [
+                    'id' => 'uuid-2',
+                    'title' => 'Second Entry That Should Be Truncated',
+                    'content' => str_repeat('B', 2000),
+                    'tags' => [],
+                    'category' => 'patterns',
+                    'priority' => 'medium',
+                    'confidence' => 80,
+                    'usage_count' => 0,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+            ]));
+
+        $this->qdrantService->shouldReceive('incrementUsage')
+            ->with('uuid-1', 'my-project')
+            ->once();
+
+        // Very small token budget - should only include first entry
+        $this->artisan('context', ['--max-tokens' => '150'])
+            ->assertSuccessful()
+            ->expectsOutputToContain('First Entry');
+    });
+
+    it('respects limit flag', function (): void {
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->with([], 10, 'my-project')
+            ->andReturn(collect([]));
+
+        $this->artisan('context', ['--limit' => '10'])
+            ->assertSuccessful();
+    });
+
+    it('skips usage tracking with no-usage flag', function (): void {
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->andReturn(collect([
+                [
+                    'id' => 'uuid-1',
+                    'title' => 'Test Entry',
+                    'content' => 'Some content.',
+                    'tags' => [],
+                    'category' => 'testing',
+                    'priority' => 'medium',
+                    'confidence' => 80,
+                    'usage_count' => 0,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+            ]));
+
+        $this->qdrantService->shouldNotReceive('incrementUsage');
+
+        $this->artisan('context', ['--no-usage' => true])
+            ->assertSuccessful();
+    });
+
+    it('increments usage_count for accessed entries', function (): void {
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->andReturn(collect([
+                [
+                    'id' => 'uuid-1',
+                    'title' => 'Entry One',
+                    'content' => 'Content one.',
+                    'tags' => ['tag1'],
+                    'category' => 'architecture',
+                    'priority' => 'high',
+                    'confidence' => 90,
+                    'usage_count' => 2,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+                [
+                    'id' => 'uuid-2',
+                    'title' => 'Entry Two',
+                    'content' => 'Content two.',
+                    'tags' => [],
+                    'category' => 'patterns',
+                    'priority' => 'medium',
+                    'confidence' => 85,
+                    'usage_count' => 1,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+            ]));
+
+        $this->qdrantService->shouldReceive('incrementUsage')
+            ->with('uuid-1', 'my-project')
+            ->once();
+
+        $this->qdrantService->shouldReceive('incrementUsage')
+            ->with('uuid-2', 'my-project')
+            ->once();
+
+        $this->artisan('context')
+            ->assertSuccessful();
+    });
+
+    it('ranks entries by usage and recency', function (): void {
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->andReturn(collect([
+                [
+                    'id' => 'uuid-old',
+                    'title' => 'Old Rarely Used',
+                    'content' => 'Old content.',
+                    'tags' => [],
+                    'category' => 'architecture',
+                    'priority' => 'low',
+                    'confidence' => 70,
+                    'usage_count' => 0,
+                    'updated_at' => now()->subDays(30)->toIso8601String(),
+                ],
+                [
+                    'id' => 'uuid-new',
+                    'title' => 'New Highly Used',
+                    'content' => 'New content.',
+                    'tags' => [],
+                    'category' => 'architecture',
+                    'priority' => 'high',
+                    'confidence' => 95,
+                    'usage_count' => 10,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+            ]));
+
+        $this->qdrantService->shouldReceive('incrementUsage')->twice();
+
+        // The highly used + recent entry should appear first
+        $result = $this->artisan('context');
+        $result->assertSuccessful();
+
+        // Capture output to verify order - new entry should be before old
+        $result->expectsOutputToContain('New Highly Used');
+    });
+
+    it('formats entries with metadata', function (): void {
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->andReturn(collect([
+                [
+                    'id' => 'uuid-1',
+                    'title' => 'Test Pattern',
+                    'content' => 'Always use Pest for testing.',
+                    'tags' => ['testing', 'pest'],
+                    'category' => 'patterns',
+                    'priority' => 'high',
+                    'confidence' => 95,
+                    'usage_count' => 5,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+            ]));
+
+        $this->qdrantService->shouldReceive('incrementUsage')->once();
+
+        $this->artisan('context')
+            ->assertSuccessful()
+            ->expectsOutputToContain('### Test Pattern')
+            ->expectsOutputToContain('Priority: high')
+            ->expectsOutputToContain('Confidence: 95%')
+            ->expectsOutputToContain('Tags: testing, pest')
+            ->expectsOutputToContain('Always use Pest for testing.');
+    });
+
+    it('handles entries with no category', function (): void {
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->andReturn(collect([
+                [
+                    'id' => 'uuid-1',
+                    'title' => 'Uncategorized Entry',
+                    'content' => 'No category set.',
+                    'tags' => [],
+                    'category' => null,
+                    'priority' => 'medium',
+                    'confidence' => 50,
+                    'usage_count' => 0,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+            ]));
+
+        $this->qdrantService->shouldReceive('incrementUsage')->once();
+
+        $this->artisan('context')
+            ->assertSuccessful()
+            ->expectsOutputToContain('## Uncategorized');
+    });
+
+    it('orders categories in predefined order', function (): void {
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->andReturn(collect([
+                [
+                    'id' => 'uuid-1',
+                    'title' => 'Gotcha First Alphabetically',
+                    'content' => 'A gotcha.',
+                    'tags' => [],
+                    'category' => 'gotchas',
+                    'priority' => 'medium',
+                    'confidence' => 80,
+                    'usage_count' => 10,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+                [
+                    'id' => 'uuid-2',
+                    'title' => 'Arch Entry',
+                    'content' => 'Architecture stuff.',
+                    'tags' => [],
+                    'category' => 'architecture',
+                    'priority' => 'high',
+                    'confidence' => 90,
+                    'usage_count' => 10,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+            ]));
+
+        $this->qdrantService->shouldReceive('incrementUsage')->twice();
+
+        // Architecture should come before gotchas in output even though
+        // gotchas was first in the scroll results
+        $this->artisan('context')
+            ->assertSuccessful()
+            ->expectsOutputToContain('## Architecture')
+            ->expectsOutputToContain('## Gotchas');
+    });
+
+    it('handles entries with empty updated_at gracefully', function (): void {
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->andReturn(collect([
+                [
+                    'id' => 'uuid-1',
+                    'title' => 'Entry Without Date',
+                    'content' => 'No date.',
+                    'tags' => [],
+                    'category' => 'testing',
+                    'priority' => 'medium',
+                    'confidence' => 50,
+                    'usage_count' => 0,
+                    'updated_at' => '',
+                ],
+            ]));
+
+        $this->qdrantService->shouldReceive('incrementUsage')->once();
+
+        $this->artisan('context')
+            ->assertSuccessful()
+            ->expectsOutputToContain('Entry Without Date');
+    });
+
+    it('handles git repo with null path gracefully', function (): void {
+        $this->gitService->shouldReceive('isGitRepository')->andReturn(true);
+        $this->gitService->shouldReceive('getRepositoryPath')->andReturn(null);
+
+        $this->qdrantService->shouldReceive('scroll')
+            ->once()
+            ->with([], 50, 'default')
+            ->andReturn(collect([]));
+
+        $this->artisan('context')
+            ->assertSuccessful();
+    });
+});


### PR DESCRIPTION
## Summary

Closes #88

- Add `know context` command for loading semantic session context as markdown for AI consumption
- Auto-detect project namespace from git repository, with `--project=` override
- Fetch entries from Qdrant, rank by recency and usage_count, group by category (architecture, patterns, decisions, gotchas, etc.)
- Token-aware output with `--max-tokens` flag (default 4000) to fit within LLM context budgets
- `--categories=` flag for filtering specific category types
- Increment `usage_count` for accessed entries (disable with `--no-usage`)
- 16 comprehensive tests covering all features and edge cases

## Test plan

- [x] PHPStan level 8 passes with no errors
- [x] Laravel Pint formatting passes
- [x] All 657 tests pass (16 new context command tests)
- [ ] Manual test: `./know context` in a git repo auto-detects project
- [ ] Manual test: `./know context --project=myproject` uses explicit project
- [ ] Manual test: `./know context --categories=architecture,decisions` filters categories
- [ ] Manual test: `./know context --max-tokens=1000` respects token budget
- [ ] Manual test: `./know context --no-usage` skips usage tracking