### PR TITLE
feat: add Redis caching layer for sub-200ms queries

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Contracts\EmbeddingServiceInterface;
+use App\Services\KnowledgeCacheService;
 use App\Services\KnowledgePathService;
 use App\Services\QdrantService;
 use App\Services\RuntimeEnvironment;
@@ -111,13 +112,17 @@ class AppServiceProvider extends ServiceProvider
             );
         });
 
+        // Knowledge cache service
+        $this->app->singleton(KnowledgeCacheService::class, fn (): \App\Services\KnowledgeCacheService => new KnowledgeCacheService);
+
         // Qdrant vector database service
         $this->app->singleton(QdrantService::class, fn ($app): \App\Services\QdrantService => new QdrantService(
             $app->make(EmbeddingServiceInterface::class),
             (int) config('search.embedding_dimension', 1024),
             (float) config('search.minimum_similarity', 0.7),
             (int) config('search.qdrant.cache_ttl', 604800),
-            (bool) config('search.qdrant.secure', false)
+            (bool) config('search.qdrant.secure', false),
+            cacheService: $app->make(KnowledgeCacheService::class)
         ));
     }
 }

--- a/app/Services/KnowledgeCacheService.php
+++ b/app/Services/KnowledgeCacheService.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+
+class KnowledgeCacheService
+{
+    private const PREFIX_EMBEDDING = 'embedding:';
+
+    private const PREFIX_SEARCH = 'search:';
+
+    private const PREFIX_STATS = 'stats:';
+
+    private const METRICS_KEY = 'cache:metrics';
+
+    private const SEARCH_KEYS_TRACKER = 'cache:keys:search';
+
+    private const STATS_KEYS_TRACKER = 'cache:keys:stats';
+
+    private const TTL_EMBEDDING = 604800; // 7 days
+
+    private const TTL_SEARCH = 3600; // 1 hour
+
+    private const TTL_STATS = 300; // 5 minutes
+
+    /**
+     * Get or compute a cached embedding.
+     *
+     * @param  callable(): array<float>  $generator
+     * @return array<float>
+     */
+    public function rememberEmbedding(string $text, callable $generator): array
+    {
+        $cacheKey = self::PREFIX_EMBEDDING.hash('xxh128', $text);
+
+        if (Cache::has($cacheKey)) {
+            $this->recordHit('embedding');
+
+            /** @var array<float> */
+            return Cache::get($cacheKey);
+        }
+
+        $this->recordMiss('embedding');
+
+        /** @var array<float> $result */
+        $result = $generator();
+
+        Cache::put($cacheKey, $result, self::TTL_EMBEDDING);
+
+        return $result;
+    }
+
+    /**
+     * Get or compute cached search results.
+     *
+     * @param  array<string, mixed>  $filters
+     * @param  callable(): array<int, array<string, mixed>>  $searcher
+     * @return array<int, array<string, mixed>>
+     */
+    public function rememberSearch(string $query, array $filters, int $limit, string $project, callable $searcher): array
+    {
+        $cacheKey = self::PREFIX_SEARCH.hash('xxh128', serialize([
+            'query' => $query,
+            'filters' => $filters,
+            'limit' => $limit,
+            'project' => $project,
+        ]));
+
+        if (Cache::has($cacheKey)) {
+            $this->recordHit('search');
+
+            /** @var array<int, array<string, mixed>> */
+            return Cache::get($cacheKey);
+        }
+
+        $this->recordMiss('search');
+
+        /** @var array<int, array<string, mixed>> $results */
+        $results = $searcher();
+
+        if ($results !== []) {
+            Cache::put($cacheKey, $results, self::TTL_SEARCH);
+            $this->trackKey(self::SEARCH_KEYS_TRACKER, $cacheKey);
+        }
+
+        return $results;
+    }
+
+    /**
+     * Get or compute cached collection stats.
+     *
+     * @param  callable(): array<string, mixed>  $fetcher
+     * @return array<string, mixed>
+     */
+    public function rememberStats(string $project, callable $fetcher): array
+    {
+        $cacheKey = self::PREFIX_STATS.$project;
+
+        if (Cache::has($cacheKey)) {
+            $this->recordHit('stats');
+
+            /** @var array<string, mixed> */
+            return Cache::get($cacheKey);
+        }
+
+        $this->recordMiss('stats');
+
+        /** @var array<string, mixed> $result */
+        $result = $fetcher();
+
+        Cache::put($cacheKey, $result, self::TTL_STATS);
+        $this->trackKey(self::STATS_KEYS_TRACKER, $cacheKey);
+
+        return $result;
+    }
+
+    /**
+     * Invalidate search and stats caches after entry mutations.
+     */
+    public function invalidateOnMutation(): void
+    {
+        $this->flushTrackedKeys(self::SEARCH_KEYS_TRACKER);
+        $this->flushTrackedKeys(self::STATS_KEYS_TRACKER);
+    }
+
+    /**
+     * Get cache metrics for display.
+     *
+     * @return array{
+     *     embedding: array{hits: int, misses: int},
+     *     search: array{hits: int, misses: int},
+     *     stats: array{hits: int, misses: int}
+     * }
+     */
+    public function getMetrics(): array
+    {
+        /** @var array<string, array{hits: int, misses: int}> $metrics */
+        $metrics = Cache::get(self::METRICS_KEY, []);
+
+        return [
+            'embedding' => $metrics['embedding'] ?? ['hits' => 0, 'misses' => 0],
+            'search' => $metrics['search'] ?? ['hits' => 0, 'misses' => 0],
+            'stats' => $metrics['stats'] ?? ['hits' => 0, 'misses' => 0],
+        ];
+    }
+
+    /**
+     * Reset cache metrics.
+     */
+    public function resetMetrics(): void
+    {
+        Cache::forget(self::METRICS_KEY);
+    }
+
+    private function recordHit(string $type): void
+    {
+        $this->updateMetric($type, 'hits');
+    }
+
+    private function recordMiss(string $type): void
+    {
+        $this->updateMetric($type, 'misses');
+    }
+
+    private function updateMetric(string $type, string $field): void
+    {
+        /** @var array<string, array{hits: int, misses: int}> $metrics */
+        $metrics = Cache::get(self::METRICS_KEY, []);
+
+        if (! isset($metrics[$type])) {
+            $metrics[$type] = ['hits' => 0, 'misses' => 0];
+        }
+
+        $metrics[$type][$field]++;
+
+        Cache::put(self::METRICS_KEY, $metrics, self::TTL_EMBEDDING);
+    }
+
+    private function trackKey(string $tracker, string $key): void
+    {
+        /** @var array<int, string> $keys */
+        $keys = Cache::get($tracker, []);
+
+        if (! in_array($key, $keys, true)) {
+            $keys[] = $key;
+            Cache::put($tracker, $keys, self::TTL_EMBEDDING);
+        }
+    }
+
+    private function flushTrackedKeys(string $tracker): void
+    {
+        /** @var array<int, string> $keys */
+        $keys = Cache::get($tracker, []);
+
+        foreach ($keys as $key) {
+            Cache::forget($key);
+        }
+
+        Cache::forget($tracker);
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -186,6 +186,11 @@ parameters:
 			path: app/Services/QdrantService.php
 
 		-
+			message: "#^Method App\\\\Services\\\\QdrantService\\:\\:executeSearch\\(\\) should return Illuminate\\\\Support\\\\Collection\\<int, array\\{id\\: int\\|string, score\\: float, title\\: string, content\\: string, tags\\: array\\<string\\>, category\\: string\\|null, module\\: string\\|null, priority\\: string\\|null, \\.\\.\\.\\}\\> but returns Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\), array\\{id\\: mixed, score\\: mixed, title\\: mixed, content\\: mixed, tags\\: mixed, category\\: mixed, module\\: mixed, priority\\: mixed, \\.\\.\\.\\}\\>\\.$#"
+			count: 1
+			path: app/Services/QdrantService.php
+
+		-
 			message: "#^Method App\\\\Services\\\\QdrantService\\:\\:hybridSearch\\(\\) should return Illuminate\\\\Support\\\\Collection\\<int, array\\{id\\: int\\|string, score\\: float, title\\: string, content\\: string, tags\\: array\\<string\\>, category\\: string\\|null, module\\: string\\|null, priority\\: string\\|null, \\.\\.\\.\\}\\> but returns Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\), array\\{id\\: mixed, score\\: mixed, title\\: mixed, content\\: mixed, tags\\: mixed, category\\: mixed, module\\: mixed, priority\\: mixed, \\.\\.\\.\\}\\>\\.$#"
 			count: 1
 			path: app/Services/QdrantService.php
@@ -196,7 +201,7 @@ parameters:
 			path: app/Services/QdrantService.php
 
 		-
-			message: "#^Method App\\\\Services\\\\QdrantService\\:\\:search\\(\\) should return Illuminate\\\\Support\\\\Collection\\<int, array\\{id\\: int\\|string, score\\: float, title\\: string, content\\: string, tags\\: array\\<string\\>, category\\: string\\|null, module\\: string\\|null, priority\\: string\\|null, \\.\\.\\.\\}\\> but returns Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\), array\\{id\\: mixed, score\\: mixed, title\\: mixed, content\\: mixed, tags\\: mixed, category\\: mixed, module\\: mixed, priority\\: mixed, \\.\\.\\.\\}\\>\\.$#"
+			message: "#^Method App\\\\Services\\\\QdrantService\\:\\:search\\(\\) should return Illuminate\\\\Support\\\\Collection\\<int, array\\{id\\: int\\|string, score\\: float, title\\: string, content\\: string, tags\\: array\\<string\\>, category\\: string\\|null, module\\: string\\|null, priority\\: string\\|null, \\.\\.\\.\\}\\> but returns Illuminate\\\\Support\\\\Collection\\<int, array\\<string, mixed\\>\\>\\.$#"
 			count: 1
 			path: app/Services/QdrantService.php
 

--- a/tests/Feature/KnowledgeStatsCommandTest.php
+++ b/tests/Feature/KnowledgeStatsCommandTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Services\KnowledgeCacheService;
 use App\Services\QdrantService;
 
 describe('KnowledgeStatsCommand', function (): void {
@@ -50,6 +51,52 @@ describe('KnowledgeStatsCommand', function (): void {
             ->once()
             ->with([], 3)
             ->andReturn($entries);
+
+        $qdrant->shouldReceive('getCacheService')
+            ->once()
+            ->andReturnNull();
+
+        $this->artisan('stats')
+            ->assertSuccessful();
+    });
+
+    it('displays cache metrics when cache service is available', function (): void {
+        $qdrant = mock(QdrantService::class);
+        $cacheService = mock(KnowledgeCacheService::class);
+        app()->instance(QdrantService::class, $qdrant);
+
+        $entries = collect([
+            [
+                'id' => 1,
+                'title' => 'Test Entry',
+                'content' => 'Content',
+                'category' => 'testing',
+                'status' => 'validated',
+                'usage_count' => 5,
+                'tags' => [],
+            ],
+        ]);
+
+        $qdrant->shouldReceive('count')
+            ->once()
+            ->andReturn(1);
+
+        $qdrant->shouldReceive('scroll')
+            ->once()
+            ->with([], 1)
+            ->andReturn($entries);
+
+        $qdrant->shouldReceive('getCacheService')
+            ->once()
+            ->andReturn($cacheService);
+
+        $cacheService->shouldReceive('getMetrics')
+            ->once()
+            ->andReturn([
+                'embedding' => ['hits' => 10, 'misses' => 5],
+                'search' => ['hits' => 20, 'misses' => 3],
+                'stats' => ['hits' => 8, 'misses' => 2],
+            ]);
 
         $this->artisan('stats')
             ->assertSuccessful();

--- a/tests/Unit/Services/KnowledgeCacheServiceTest.php
+++ b/tests/Unit/Services/KnowledgeCacheServiceTest.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\KnowledgeCacheService;
+use Illuminate\Support\Facades\Cache;
+
+uses()->group('cache-unit');
+
+beforeEach(function (): void {
+    Cache::flush();
+    $this->cacheService = new KnowledgeCacheService;
+});
+
+describe('rememberEmbedding', function (): void {
+    it('generates embedding on cache miss', function (): void {
+        $called = false;
+        $result = $this->cacheService->rememberEmbedding('test text', function () use (&$called): array {
+            $called = true;
+
+            return [0.1, 0.2, 0.3];
+        });
+
+        expect($called)->toBeTrue();
+        expect($result)->toBe([0.1, 0.2, 0.3]);
+    });
+
+    it('returns cached embedding on cache hit', function (): void {
+        $callCount = 0;
+        $generator = function () use (&$callCount): array {
+            $callCount++;
+
+            return [0.1, 0.2, 0.3];
+        };
+
+        $this->cacheService->rememberEmbedding('test text', $generator);
+        $result = $this->cacheService->rememberEmbedding('test text', $generator);
+
+        expect($callCount)->toBe(1);
+        expect($result)->toBe([0.1, 0.2, 0.3]);
+    });
+
+    it('uses different cache keys for different text', function (): void {
+        $callCount = 0;
+        $generator = function () use (&$callCount): array {
+            $callCount++;
+
+            return [0.1 * $callCount, 0.2 * $callCount];
+        };
+
+        $result1 = $this->cacheService->rememberEmbedding('text one', $generator);
+        $result2 = $this->cacheService->rememberEmbedding('text two', $generator);
+
+        expect($callCount)->toBe(2);
+        expect($result1)->not->toBe($result2);
+    });
+
+    it('records embedding hit metric', function (): void {
+        $this->cacheService->rememberEmbedding('test', fn (): array => [0.1]);
+        $this->cacheService->rememberEmbedding('test', fn (): array => [0.1]);
+
+        $metrics = $this->cacheService->getMetrics();
+        expect($metrics['embedding']['hits'])->toBe(1);
+        expect($metrics['embedding']['misses'])->toBe(1);
+    });
+});
+
+describe('rememberSearch', function (): void {
+    it('executes searcher on cache miss', function (): void {
+        $called = false;
+        $result = $this->cacheService->rememberSearch('query', [], 10, 'default', function () use (&$called): array {
+            $called = true;
+
+            return [['id' => '1', 'title' => 'Result']];
+        });
+
+        expect($called)->toBeTrue();
+        expect($result)->toBe([['id' => '1', 'title' => 'Result']]);
+    });
+
+    it('returns cached results on cache hit', function (): void {
+        $callCount = 0;
+        $searcher = function () use (&$callCount): array {
+            $callCount++;
+
+            return [['id' => '1', 'title' => 'Result']];
+        };
+
+        $this->cacheService->rememberSearch('query', [], 10, 'default', $searcher);
+        $result = $this->cacheService->rememberSearch('query', [], 10, 'default', $searcher);
+
+        expect($callCount)->toBe(1);
+        expect($result)->toBe([['id' => '1', 'title' => 'Result']]);
+    });
+
+    it('does not cache empty results', function (): void {
+        $callCount = 0;
+        $searcher = function () use (&$callCount): array {
+            $callCount++;
+
+            return [];
+        };
+
+        $this->cacheService->rememberSearch('query', [], 10, 'default', $searcher);
+        $this->cacheService->rememberSearch('query', [], 10, 'default', $searcher);
+
+        expect($callCount)->toBe(2);
+    });
+
+    it('uses different keys for different queries', function (): void {
+        $callCount = 0;
+        $searcher = function () use (&$callCount): array {
+            $callCount++;
+
+            return [['id' => (string) $callCount]];
+        };
+
+        $this->cacheService->rememberSearch('query1', [], 10, 'default', $searcher);
+        $this->cacheService->rememberSearch('query2', [], 10, 'default', $searcher);
+
+        expect($callCount)->toBe(2);
+    });
+
+    it('uses different keys for different filters', function (): void {
+        $callCount = 0;
+        $searcher = function () use (&$callCount): array {
+            $callCount++;
+
+            return [['id' => (string) $callCount]];
+        };
+
+        $this->cacheService->rememberSearch('query', ['category' => 'a'], 10, 'default', $searcher);
+        $this->cacheService->rememberSearch('query', ['category' => 'b'], 10, 'default', $searcher);
+
+        expect($callCount)->toBe(2);
+    });
+
+    it('records search hit metric', function (): void {
+        $this->cacheService->rememberSearch('q', [], 10, 'default', fn (): array => [['id' => '1']]);
+        $this->cacheService->rememberSearch('q', [], 10, 'default', fn (): array => [['id' => '1']]);
+
+        $metrics = $this->cacheService->getMetrics();
+        expect($metrics['search']['hits'])->toBe(1);
+        expect($metrics['search']['misses'])->toBe(1);
+    });
+});
+
+describe('rememberStats', function (): void {
+    it('executes fetcher on cache miss', function (): void {
+        $called = false;
+        $result = $this->cacheService->rememberStats('default', function () use (&$called): array {
+            $called = true;
+
+            return ['points_count' => 42];
+        });
+
+        expect($called)->toBeTrue();
+        expect($result)->toBe(['points_count' => 42]);
+    });
+
+    it('returns cached stats on hit', function (): void {
+        $callCount = 0;
+        $fetcher = function () use (&$callCount): array {
+            $callCount++;
+
+            return ['points_count' => 42];
+        };
+
+        $this->cacheService->rememberStats('default', $fetcher);
+        $result = $this->cacheService->rememberStats('default', $fetcher);
+
+        expect($callCount)->toBe(1);
+        expect($result)->toBe(['points_count' => 42]);
+    });
+
+    it('uses different keys for different projects', function (): void {
+        $callCount = 0;
+        $fetcher = function () use (&$callCount): array {
+            $callCount++;
+
+            return ['points_count' => $callCount * 10];
+        };
+
+        $this->cacheService->rememberStats('project-a', $fetcher);
+        $this->cacheService->rememberStats('project-b', $fetcher);
+
+        expect($callCount)->toBe(2);
+    });
+
+    it('records stats hit metric', function (): void {
+        $this->cacheService->rememberStats('default', fn (): array => ['points_count' => 1]);
+        $this->cacheService->rememberStats('default', fn (): array => ['points_count' => 1]);
+
+        $metrics = $this->cacheService->getMetrics();
+        expect($metrics['stats']['hits'])->toBe(1);
+        expect($metrics['stats']['misses'])->toBe(1);
+    });
+});
+
+describe('invalidateOnMutation', function (): void {
+    it('clears search cache after invalidation', function (): void {
+        $callCount = 0;
+        $searcher = function () use (&$callCount): array {
+            $callCount++;
+
+            return [['id' => (string) $callCount]];
+        };
+
+        // Prime the cache
+        $this->cacheService->rememberSearch('query', [], 10, 'default', $searcher);
+        expect($callCount)->toBe(1);
+
+        // Invalidate
+        $this->cacheService->invalidateOnMutation();
+
+        // Should call searcher again
+        $this->cacheService->rememberSearch('query', [], 10, 'default', $searcher);
+        expect($callCount)->toBe(2);
+    });
+
+    it('clears stats cache after invalidation', function (): void {
+        $callCount = 0;
+        $fetcher = function () use (&$callCount): array {
+            $callCount++;
+
+            return ['points_count' => $callCount];
+        };
+
+        // Prime the cache
+        $this->cacheService->rememberStats('default', $fetcher);
+        expect($callCount)->toBe(1);
+
+        // Invalidate
+        $this->cacheService->invalidateOnMutation();
+
+        // Should call fetcher again
+        $this->cacheService->rememberStats('default', $fetcher);
+        expect($callCount)->toBe(2);
+    });
+
+    it('does not clear embedding cache on invalidation', function (): void {
+        $callCount = 0;
+        $generator = function () use (&$callCount): array {
+            $callCount++;
+
+            return [0.1, 0.2];
+        };
+
+        // Prime embedding cache
+        $this->cacheService->rememberEmbedding('text', $generator);
+        expect($callCount)->toBe(1);
+
+        // Invalidate
+        $this->cacheService->invalidateOnMutation();
+
+        // Embedding cache should still be valid
+        $this->cacheService->rememberEmbedding('text', $generator);
+        expect($callCount)->toBe(1);
+    });
+});
+
+describe('getMetrics', function (): void {
+    it('returns zero metrics when no activity', function (): void {
+        $metrics = $this->cacheService->getMetrics();
+
+        expect($metrics)->toBe([
+            'embedding' => ['hits' => 0, 'misses' => 0],
+            'search' => ['hits' => 0, 'misses' => 0],
+            'stats' => ['hits' => 0, 'misses' => 0],
+        ]);
+    });
+
+    it('tracks metrics across all cache types', function (): void {
+        // Generate misses
+        $this->cacheService->rememberEmbedding('t1', fn (): array => [0.1]);
+        $this->cacheService->rememberSearch('q', [], 10, 'default', fn (): array => [['id' => '1']]);
+        $this->cacheService->rememberStats('default', fn (): array => ['count' => 1]);
+
+        // Generate hits
+        $this->cacheService->rememberEmbedding('t1', fn (): array => [0.1]);
+        $this->cacheService->rememberSearch('q', [], 10, 'default', fn (): array => [['id' => '1']]);
+        $this->cacheService->rememberStats('default', fn (): array => ['count' => 1]);
+
+        $metrics = $this->cacheService->getMetrics();
+
+        expect($metrics['embedding'])->toBe(['hits' => 1, 'misses' => 1]);
+        expect($metrics['search'])->toBe(['hits' => 1, 'misses' => 1]);
+        expect($metrics['stats'])->toBe(['hits' => 1, 'misses' => 1]);
+    });
+});
+
+describe('resetMetrics', function (): void {
+    it('clears all metrics', function (): void {
+        $this->cacheService->rememberEmbedding('t', fn (): array => [0.1]);
+        $this->cacheService->resetMetrics();
+
+        $metrics = $this->cacheService->getMetrics();
+
+        expect($metrics['embedding'])->toBe(['hits' => 0, 'misses' => 0]);
+    });
+});


### PR DESCRIPTION
## Summary
- Add `KnowledgeCacheService` with Redis-backed caching for embeddings (7-day TTL), search results (1-hour TTL), and Qdrant collection stats (5-min TTL)
- Integrate cache layer into `QdrantService` for transparent cache-through on search and embedding operations, with automatic invalidation on entry updates
- Display cache hit/miss metrics in `know stats` command

Closes #79

## Test plan
- [x] Unit tests for `KnowledgeCacheService` (embedding, search, stats caching + invalidation)
- [x] Feature test for `know stats` cache metrics display
- [x] All 662 tests passing, 5 skipped (pre-existing)
- [ ] Manual verification with Redis running to confirm sub-200ms cached queries