### PR TITLE
fix: restore service commands with Termwind-compatible styling

### DIFF
--- a/app/Commands/Service/DownCommand.php
+++ b/app/Commands/Service/DownCommand.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands\Service;
+
+use Illuminate\Support\Facades\Process;
+use LaravelZero\Framework\Commands\Command;
+
+use function Laravel\Prompts\confirm;
+use function Termwind\render;
+
+class DownCommand extends Command
+{
+    protected $signature = 'service:down
+                            {--volumes : Remove volumes}
+                            {--odin : Use Odin (remote) configuration}
+                            {--force : Skip confirmation prompts}';
+
+    protected $description = 'Stop knowledge services';
+
+    public function handle(): int
+    {
+        $composeFile = $this->option('odin') === true
+            ? 'docker-compose.odin.yml'
+            : 'docker-compose.yml';
+
+        $environment = $this->option('odin') === true ? 'Odin (Remote)' : 'Local';
+
+        if (! file_exists(base_path($composeFile))) {
+            render(<<<HTML
+                <div class="mx-2 my-1">
+                    <div class="px-4 py-2 bg-red-900">
+                        <div class="text-red-400 font-bold">✗ Configuration Error</div>
+                        <div class="text-red-300 mt-1">Docker Compose file not found: {$composeFile}</div>
+                    </div>
+                </div>
+            HTML);
+
+            return self::FAILURE;
+        }
+
+        // Show warning if removing volumes
+        if ($this->option('volumes') === true && $this->option('force') !== true) {
+            render(<<<'HTML'
+                <div class="mx-2 my-1">
+                    <div class="px-4 py-2 bg-yellow-900">
+                        <div>
+                            <span class="text-yellow-400 mr-3">⚠</span>
+                            <span class="text-yellow-300 font-bold">Warning: Volume Removal</span>
+                        </div>
+                        <div class="text-gray-300 mt-1 ml-6">This will permanently delete all data stored in volumes</div>
+                    </div>
+                </div>
+            HTML);
+
+            $confirmed = confirm(
+                label: 'Are you sure you want to remove volumes?',
+                default: false,
+                hint: 'This action cannot be undone'
+            );
+
+            if (! $confirmed) {
+                render(<<<'HTML'
+                    <div class="mx-2 my-1">
+                        <div class="px-4 py-2 bg-gray-800">
+                            <div class="text-gray-400">Operation cancelled</div>
+                        </div>
+                    </div>
+                HTML);
+
+                return self::SUCCESS;
+            }
+        }
+
+        // Display shutdown banner
+        render(<<<HTML
+            <div class="mx-2 my-1">
+                <div class="px-4 py-2 bg-orange-900">
+                    <div>
+                        <span class="text-orange-400 mr-3">■</span>
+                        <span class="text-orange-300 font-bold">Stopping Knowledge Services</span>
+                    </div>
+                    <div class="text-gray-400 ml-6">Environment: {$environment}</div>
+                </div>
+            </div>
+        HTML);
+
+        $args = ['docker', 'compose', '-f', $composeFile, 'down'];
+
+        if ($this->option('volumes') === true) {
+            $args[] = '-v';
+        }
+
+        $result = Process::forever()
+            ->path(base_path())
+            ->run($args);
+
+        $exitCode = $result->exitCode();
+
+        if ($exitCode === 0) {
+            $volumeText = $this->option('volumes') === true ? ' and volumes removed' : '';
+
+            render(<<<HTML
+                <div class="mx-2 my-1">
+                    <div class="px-4 py-2 bg-green-900">
+                        <div>
+                            <span class="text-green-400 mr-3">✓</span>
+                            <span class="text-green-300 font-bold">Services Stopped Successfully</span>
+                        </div>
+                        <div class="text-gray-400 mt-1 ml-6">All containers have been stopped{$volumeText}</div>
+                    </div>
+                </div>
+            HTML);
+
+            if ($this->option('volumes') !== true) {
+                render(<<<'HTML'
+                    <div class="mx-2 my-1">
+                        <div class="px-4 py-2 bg-gray-800">
+                            <div class="text-gray-400">
+                                <span>Tip: Use </span>
+                                <span class="text-cyan-400">know service:down --volumes</span>
+                                <span> to remove data volumes</span>
+                            </div>
+                        </div>
+                    </div>
+                HTML);
+            }
+
+            return self::SUCCESS;
+        }
+
+        render(<<<'HTML'
+            <div class="mx-2 my-1">
+                <div class="px-4 py-2 bg-red-900">
+                    <div>
+                        <span class="text-red-400 mr-3">✗</span>
+                        <span class="text-red-300 font-bold">Failed to Stop Services</span>
+                    </div>
+                    <div class="text-gray-400 mt-1 ml-6">Check the error output above for details</div>
+                </div>
+            </div>
+        HTML);
+
+        return self::FAILURE;
+    }
+}

--- a/app/Commands/Service/LogsCommand.php
+++ b/app/Commands/Service/LogsCommand.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands\Service;
+
+use Illuminate\Support\Facades\Process;
+use LaravelZero\Framework\Commands\Command;
+
+use function Laravel\Prompts\select;
+use function Termwind\render;
+
+class LogsCommand extends Command
+{
+    protected $signature = 'service:logs
+                            {service? : Specific service (qdrant, redis, embeddings, ollama)}
+                            {--f|follow : Follow log output}
+                            {--tail=50 : Number of lines to show}
+                            {--odin : Use Odin (remote) configuration}';
+
+    protected $description = 'View service logs';
+
+    public function handle(): int
+    {
+        $composeFile = $this->option('odin') === true
+            ? 'docker-compose.odin.yml'
+            : 'docker-compose.yml';
+
+        $environment = $this->option('odin') === true ? 'Odin (Remote)' : 'Local';
+
+        if (! file_exists(base_path($composeFile))) {
+            render(<<<HTML
+                <div class="mx-2 my-1">
+                    <div class="px-4 py-2 bg-red-900">
+                        <div class="text-red-400 font-bold">✗ Configuration Error</div>
+                        <div class="text-red-300 mt-1">Docker Compose file not found: {$composeFile}</div>
+                    </div>
+                </div>
+            HTML);
+
+            return self::FAILURE;
+        }
+
+        /** @var string|null $service */
+        $service = $this->argument('service');
+
+        // If no service specified and not following, offer selection
+        if ($service === null && $this->option('follow') !== true) {
+            $service = select(
+                label: 'Which service logs would you like to view?',
+                options: [
+                    'all' => 'All Services',
+                    'qdrant' => 'Qdrant (Vector Database)',
+                    'redis' => 'Redis (Cache)',
+                    'embeddings' => 'Embeddings (ML Service)',
+                    'ollama' => 'Ollama (LLM Engine)',
+                ],
+                default: 'all'
+            );
+
+            if ($service === 'all') {
+                $service = null;
+            }
+        }
+
+        $serviceDisplay = is_string($service) ? ucfirst($service) : 'All Services';
+        $followMode = $this->option('follow') === true ? 'Live' : 'Recent';
+        $tailOption = $this->option('tail');
+        $tailCount = is_string($tailOption) || is_int($tailOption) ? (string) $tailOption : '50';
+
+        // Display logs banner
+        render(<<<HTML
+            <div class="mx-2 my-1">
+                <div class="px-4 py-2 bg-purple-900">
+                    <div>
+                        <span class="text-purple-400 mr-3">📋</span>
+                        <span class="text-purple-300 font-bold">Service Logs: {$serviceDisplay}</span>
+                    </div>
+                    <div class="ml-6">
+                        <span class="text-gray-400">Environment: {$environment}</span>
+                        <span class="text-gray-500 ml-2">·</span>
+                        <span class="text-purple-300 font-bold ml-2">{$followMode}</span>
+                        <span class="text-gray-400 ml-2">·</span>
+                        <span class="text-gray-400 ml-2">Last {$tailCount} lines</span>
+                    </div>
+                </div>
+            </div>
+        HTML);
+
+        if ($this->option('follow') === true) {
+            render(<<<'HTML'
+                <div class="mx-2 my-1">
+                    <div class="px-4 py-1 bg-gray-800">
+                        <div class="text-gray-400">
+                            <span>Press </span><span class="text-cyan-400">Ctrl+C</span><span> to stop following logs</span>
+                        </div>
+                    </div>
+                </div>
+            HTML);
+        }
+
+        $this->newLine();
+
+        $args = ['docker', 'compose', '-f', $composeFile, 'logs'];
+
+        if ($this->option('follow') === true) {
+            $args[] = '-f';
+        }
+
+        $tailOption = $this->option('tail');
+        if (is_string($tailOption) || is_int($tailOption)) {
+            $args[] = '--tail='.(string) $tailOption;
+        }
+
+        if (is_string($service)) {
+            $args[] = $service;
+        }
+
+        $result = Process::forever()
+            ->path(base_path())
+            ->run($args);
+
+        $exitCode = $result->exitCode() ?? self::FAILURE;
+
+        // Only show footer if not following (Ctrl+C will interrupt)
+        if ($this->option('follow') !== true) {
+            $this->newLine();
+            render(<<<'HTML'
+                <div class="mx-2 my-1">
+                    <div class="px-4 py-1 bg-gray-800">
+                        <div class="text-gray-400">
+                            <span>Tip: Use </span>
+                            <span class="text-cyan-400">--follow</span>
+                            <span> to stream logs in real-time</span>
+                        </div>
+                    </div>
+                </div>
+            HTML);
+        }
+
+        return $exitCode;
+    }
+}

--- a/app/Commands/Service/StatusCommand.php
+++ b/app/Commands/Service/StatusCommand.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands\Service;
+
+use App\Contracts\HealthCheckInterface;
+use Illuminate\Support\Facades\Process;
+use LaravelZero\Framework\Commands\Command;
+
+use function Laravel\Prompts\spin;
+use function Termwind\render;
+
+class StatusCommand extends Command
+{
+    protected $signature = 'service:status
+                            {--odin : Use Odin (remote) configuration}';
+
+    protected $description = 'Check service health status';
+
+    public function __construct(
+        private readonly HealthCheckInterface $healthCheck
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $composeFile = $this->option('odin') === true
+            ? 'docker-compose.odin.yml'
+            : 'docker-compose.yml';
+
+        $environment = $this->option('odin') === true ? 'Odin (Remote)' : 'Local';
+
+        // Perform health checks with spinner
+        $healthData = spin(
+            fn () => $this->healthCheck->checkAll(),
+            'Checking service health...'
+        );
+
+        // Get container status
+        $containerStatus = $this->getContainerStatus($composeFile);
+
+        // Render beautiful dashboard
+        $this->renderDashboard($environment, $healthData, $containerStatus);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function getContainerStatus(string $composeFile): array
+    {
+        $result = Process::path(base_path())
+            ->run(['docker', 'compose', '-f', $composeFile, 'ps', '--format', 'json']);
+
+        if (! $result->successful()) {
+            return [];
+        }
+
+        $output = $result->output();
+        if ($output === '') {
+            return [];
+        }
+
+        $containers = [];
+        foreach (explode("\n", trim($output)) as $line) {
+            if ($line === '') {
+                continue;
+            }
+            $data = json_decode($line, true);
+            if (is_array($data) && count($data) > 0) {
+                $containers[] = $data;
+            }
+        }
+
+        return $containers;
+    }
+
+    /**
+     * @param  array<int, array{name: string, healthy: bool, endpoint: string, type: string}>  $healthData
+     * @param  array<int, array<string, mixed>>  $containers
+     */
+    private function renderDashboard(string $environment, array $healthData, array $containers): void
+    {
+        $allHealthy = collect($healthData)->every(fn ($service) => $service['healthy']);
+        $healthyCount = collect($healthData)->filter(fn ($service) => $service['healthy'])->count();
+        $totalCount = count($healthData);
+
+        $statusColor = $allHealthy ? 'green' : ($healthyCount > 0 ? 'yellow' : 'red');
+        $statusText = $allHealthy ? 'All Systems Operational' : ($healthyCount > 0 ? 'Partial Outage' : 'Major Outage');
+        $statusIcon = '●';
+
+        render(<<<HTML
+            <div class="mx-2 my-1">
+                <div class="px-4 py-2 bg-gray-800">
+                    <div>
+                        <span class="text-gray-400 font-bold">KNOWLEDGE SERVICE STATUS</span>
+                        <span class="ml-2 text-gray-500">·</span>
+                        <span class="ml-2 text-gray-400">{$environment}</span>
+                    </div>
+                    <div class="mt-1">
+                        <span class="text-{$statusColor} mr-2">{$statusIcon}</span>
+                        <span class="text-{$statusColor} font-bold">{$statusText}</span>
+                        <span class="ml-3 text-gray-500">{$healthyCount}/{$totalCount}</span>
+                    </div>
+                </div>
+            </div>
+        HTML);
+
+        // Service Health Cards
+        render(<<<'HTML'
+            <div class="mx-2 my-1">
+                <div class="px-2 py-1">
+                    <span class="text-gray-400 font-bold">SERVICE HEALTH</span>
+                </div>
+            </div>
+        HTML);
+
+        foreach ($healthData as $service) {
+            $color = $service['healthy'] ? 'green' : 'red';
+            $icon = $service['healthy'] ? '✓' : '✗';
+            $status = $service['healthy'] ? 'Healthy' : 'Unhealthy';
+
+            $name = $service['name'];
+            $type = $service['type'];
+            $endpoint = $service['endpoint'];
+
+            render(<<<HTML
+                <div class="mx-2">
+                    <div class="px-4 py-2 bg-gray-900 mb-1">
+                        <div>
+                            <span class="text-{$color} mr-3">{$icon}</span>
+                            <span class="text-white font-bold">{$name}</span>
+                            <span class="text-{$color} font-bold ml-2">{$status}</span>
+                        </div>
+                        <div class="ml-6">
+                            <span class="text-gray-500">{$type}</span>
+                            <span class="text-gray-500 ml-2">·</span>
+                            <span class="text-gray-500 ml-2">{$endpoint}</span>
+                        </div>
+                    </div>
+                </div>
+            HTML);
+        }
+
+        // Container Status
+        if (count($containers) > 0) {
+            render(<<<'HTML'
+                <div class="mx-2 my-1 mt-2">
+                    <div class="px-2 py-1">
+                        <span class="text-gray-400 font-bold">CONTAINERS</span>
+                    </div>
+                </div>
+            HTML);
+
+            foreach ($containers as $container) {
+                $state = $container['State'] ?? 'unknown';
+                $name = $container['Service'] ?? $container['Name'] ?? 'unknown';
+
+                $stateColor = match ($state) {
+                    'running' => 'green',
+                    'exited' => 'red',
+                    'paused' => 'yellow',
+                    default => 'gray',
+                };
+
+                $stateIcon = match ($state) {
+                    'running' => '▶',
+                    'exited' => '■',
+                    'paused' => '❙❙',
+                    default => '?',
+                };
+
+                render(<<<HTML
+                    <div class="mx-2">
+                        <div class="px-4 py-1 bg-gray-900 mb-1">
+                            <div>
+                                <span class="text-{$stateColor} mr-3">{$stateIcon}</span>
+                                <span class="text-white">{$name}</span>
+                                <span class="text-{$stateColor} uppercase ml-2">{$state}</span>
+                            </div>
+                        </div>
+                    </div>
+                HTML);
+            }
+        }
+
+        // Footer
+        render(<<<'HTML'
+            <div class="mx-2 my-1 mt-1">
+                <div class="px-2 text-gray-500">
+                    <span>Run </span><span class="text-cyan-400">know service:logs</span><span> to view service logs</span>
+                </div>
+            </div>
+        HTML);
+    }
+}

--- a/app/Commands/Service/UpCommand.php
+++ b/app/Commands/Service/UpCommand.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands\Service;
+
+use Illuminate\Support\Facades\Process;
+use LaravelZero\Framework\Commands\Command;
+
+use function Termwind\render;
+
+class UpCommand extends Command
+{
+    protected $signature = 'service:up
+                            {--d|detach : Run in detached mode}
+                            {--odin : Use Odin (remote) configuration}';
+
+    protected $description = 'Start knowledge services (Qdrant, Redis, Embeddings)';
+
+    public function handle(): int
+    {
+        $composeFile = $this->option('odin') === true
+            ? 'docker-compose.odin.yml'
+            : 'docker-compose.yml';
+
+        $environment = $this->option('odin') === true ? 'Odin (Remote)' : 'Local';
+
+        if (! file_exists(base_path($composeFile))) {
+            render(<<<HTML
+                <div class="mx-2 my-1">
+                    <div class="px-4 py-2 bg-red-900">
+                        <div class="text-red-400 font-bold">✗ Configuration Error</div>
+                        <div class="text-red-300 mt-1">Docker Compose file not found: {$composeFile}</div>
+                        <div class="text-gray-400 mt-2">
+                            <span>Run </span><span class="text-cyan-400">know service:init</span><span> to initialize</span>
+                        </div>
+                    </div>
+                </div>
+            HTML);
+
+            return self::FAILURE;
+        }
+
+        // Display startup banner
+        render(<<<HTML
+            <div class="mx-2 my-1">
+                <div class="px-4 py-2 bg-blue-900">
+                    <div>
+                        <span class="text-blue-400 mr-3">▶</span>
+                        <span class="text-blue-300 font-bold">Starting Knowledge Services</span>
+                    </div>
+                    <div class="text-gray-400 ml-6">Environment: {$environment}</div>
+                </div>
+            </div>
+        HTML);
+
+        $args = ['docker', 'compose', '-f', $composeFile, 'up'];
+
+        if ($this->option('detach') === true) {
+            $args[] = '-d';
+        }
+
+        $result = Process::forever()
+            ->path(base_path())
+            ->run($args);
+
+        $exitCode = $result->exitCode();
+
+        if ($exitCode === 0) {
+            if ($this->option('detach') === true) {
+                render(<<<'HTML'
+                    <div class="mx-2 my-1">
+                        <div class="px-4 py-2 bg-green-900">
+                            <div>
+                                <span class="text-green-400 mr-3">✓</span>
+                                <span class="text-green-300 font-bold">Services Started Successfully</span>
+                            </div>
+                            <div class="text-gray-400 mt-1 ml-6">All containers are running in detached mode</div>
+                        </div>
+                    </div>
+                HTML);
+
+                render(<<<'HTML'
+                    <div class="mx-2 my-1">
+                        <div class="px-4 py-2 bg-gray-800">
+                            <div class="text-gray-400 font-bold mb-2">NEXT STEPS</div>
+                            <div class="mb-1">
+                                <span class="text-cyan-400 mr-2">→</span>
+                                <span class="text-gray-300">Check status: </span>
+                                <span class="text-cyan-400 ml-1">know service:status</span>
+                            </div>
+                            <div class="mb-1">
+                                <span class="text-cyan-400 mr-2">→</span>
+                                <span class="text-gray-300">View logs: </span>
+                                <span class="text-cyan-400 ml-1">know service:logs</span>
+                            </div>
+                            <div>
+                                <span class="text-cyan-400 mr-2">→</span>
+                                <span class="text-gray-300">Stop services: </span>
+                                <span class="text-cyan-400 ml-1">know service:down</span>
+                            </div>
+                        </div>
+                    </div>
+                HTML);
+            }
+
+            return self::SUCCESS;
+        }
+
+        render(<<<'HTML'
+            <div class="mx-2 my-1">
+                <div class="px-4 py-2 bg-red-900">
+                    <div>
+                        <span class="text-red-400 mr-3">✗</span>
+                        <span class="text-red-300 font-bold">Failed to Start Services</span>
+                    </div>
+                    <div class="text-gray-400 mt-1 ml-6">Check the error output above for details</div>
+                </div>
+            </div>
+        HTML);
+
+        return self::FAILURE;
+    }
+}

--- a/app/Contracts/HealthCheckInterface.php
+++ b/app/Contracts/HealthCheckInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+interface HealthCheckInterface
+{
+    /**
+     * Check if a service is healthy.
+     *
+     * @return array{name: string, healthy: bool, endpoint: string, type: string}
+     */
+    public function check(string $service): array;
+
+    /**
+     * Check all services and return their health status.
+     *
+     * @return array<int, array{name: string, healthy: bool, endpoint: string, type: string}>
+     */
+    public function checkAll(): array;
+
+    /**
+     * Get list of available services.
+     *
+     * @return array<string>
+     */
+    public function getServices(): array;
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,8 +3,10 @@
 namespace App\Providers;
 
 use App\Contracts\EmbeddingServiceInterface;
+use App\Contracts\HealthCheckInterface;
 use App\Services\DailyLogService;
 use App\Services\DeletionTracker;
+use App\Services\HealthCheckService;
 use App\Services\KnowledgeCacheService;
 use App\Services\KnowledgePathService;
 use App\Services\OdinSyncService;
@@ -160,5 +162,8 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(DailyLogService::class, fn ($app): \App\Services\DailyLogService => new DailyLogService(
             $app->make(KnowledgePathService::class)
         ));
+
+        // Health check service for service status commands
+        $this->app->singleton(HealthCheckInterface::class, fn (): HealthCheckService => new HealthCheckService);
     }
 }

--- a/app/Services/HealthCheckService.php
+++ b/app/Services/HealthCheckService.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\HealthCheckInterface;
+use Redis;
+
+class HealthCheckService implements HealthCheckInterface
+{
+    private const TIMEOUT_SECONDS = 2;
+
+    /**
+     * @var array<string, array{name: string, type: string, checker: callable}>
+     */
+    private array $services;
+
+    public function __construct()
+    {
+        $this->services = [
+            'qdrant' => [
+                'name' => 'Qdrant',
+                'type' => 'Vector Database',
+                'checker' => fn () => $this->checkQdrant(),
+            ],
+            'redis' => [
+                'name' => 'Redis',
+                'type' => 'Cache',
+                'checker' => fn () => $this->checkRedis(),
+            ],
+            'embeddings' => [
+                'name' => 'Embeddings',
+                'type' => 'ML Service',
+                'checker' => fn () => $this->checkEmbeddings(),
+            ],
+            'ollama' => [
+                'name' => 'Ollama',
+                'type' => 'LLM Engine',
+                'checker' => fn () => $this->checkOllama(),
+            ],
+        ];
+    }
+
+    public function check(string $service): array
+    {
+        if (! isset($this->services[$service])) {
+            return [
+                'name' => $service,
+                'healthy' => false,
+                'endpoint' => 'unknown',
+                'type' => 'Unknown',
+            ];
+        }
+
+        $config = $this->services[$service];
+        $endpoint = $this->getEndpoint($service);
+
+        return [
+            'name' => $config['name'],
+            'healthy' => ($config['checker'])(),
+            'endpoint' => $endpoint,
+            'type' => $config['type'],
+        ];
+    }
+
+    public function checkAll(): array
+    {
+        return array_map(
+            fn (string $service) => $this->check($service),
+            $this->getServices()
+        );
+    }
+
+    public function getServices(): array
+    {
+        return array_keys($this->services);
+    }
+
+    private function getEndpoint(string $service): string
+    {
+        return match ($service) {
+            'qdrant' => config('search.qdrant.host', 'localhost').':'.config('search.qdrant.port', 6333),
+            'redis' => config('database.redis.default.host', '127.0.0.1').':'.config('database.redis.default.port', 6380),
+            'embeddings' => config('search.qdrant.embedding_server', 'http://localhost:8001'),
+            'ollama' => config('search.ollama.host', 'localhost').':'.config('search.ollama.port', 11434),
+            default => 'unknown',
+        };
+    }
+
+    private function checkQdrant(): bool
+    {
+        $host = config('search.qdrant.host', 'localhost');
+        $port = config('search.qdrant.port', 6333);
+
+        return $this->httpCheck("http://{$host}:{$port}/healthz");
+    }
+
+    private function checkRedis(): bool
+    {
+        if (! extension_loaded('redis')) {
+            return false;
+        }
+
+        try {
+            $redis = new Redis;
+            $host = config('database.redis.default.host', '127.0.0.1');
+            $port = (int) config('database.redis.default.port', 6380);
+
+            return $redis->connect($host, $port, self::TIMEOUT_SECONDS);
+        } catch (\Exception) {
+            return false;
+        }
+    }
+
+    private function checkEmbeddings(): bool
+    {
+        $server = config('search.qdrant.embedding_server', 'http://localhost:8001');
+
+        return $this->httpCheck("{$server}/health");
+    }
+
+    private function checkOllama(): bool
+    {
+        $host = config('search.ollama.host', 'localhost');
+        $port = config('search.ollama.port', 11434);
+
+        return $this->httpCheck("http://{$host}:{$port}/api/tags");
+    }
+
+    private function httpCheck(string $url): bool
+    {
+        $context = stream_context_create([
+            'http' => [
+                'timeout' => self::TIMEOUT_SECONDS,
+                'method' => 'GET',
+            ],
+        ]);
+
+        return @file_get_contents($url, false, $context) !== false;
+    }
+}

--- a/tests/Feature/AppServiceProviderTest.php
+++ b/tests/Feature/AppServiceProviderTest.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use App\Contracts\EmbeddingServiceInterface;
+use App\Contracts\HealthCheckInterface;
 use App\Services\EmbeddingService;
+use App\Services\HealthCheckService;
 use App\Services\KnowledgePathService;
 use App\Services\QdrantService;
 use App\Services\RuntimeEnvironment;
@@ -86,6 +88,12 @@ describe('AppServiceProvider', function (): void {
         $service = app(QdrantService::class);
 
         expect($service)->toBeInstanceOf(QdrantService::class);
+    });
+
+    it('registers HealthCheckService', function (): void {
+        $service = app(HealthCheckInterface::class);
+
+        expect($service)->toBeInstanceOf(HealthCheckService::class);
     });
 
     it('uses custom embedding server configuration for qdrant provider', function (): void {

--- a/tests/Feature/Commands/Service/DownCommandTest.php
+++ b/tests/Feature/Commands/Service/DownCommandTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Process;
+
+describe('service:down command', function () {
+    beforeEach(function () {
+        // Fake all docker commands by default
+        Process::fake([
+            '*docker*' => Process::result(output: 'OK', exitCode: 0),
+        ]);
+    });
+
+    describe('configuration file validation', function () {
+        it('fails when local docker-compose file does not exist', function () {
+            $tempDir = sys_get_temp_dir().'/know-test-'.uniqid();
+            mkdir($tempDir, 0755, true);
+            $this->app->setBasePath($tempDir);
+
+            try {
+                $this->artisan('service:down')
+                    ->assertFailed();
+            } finally {
+                rmdir($tempDir);
+            }
+        });
+
+        it('fails when odin docker-compose file does not exist', function () {
+            $tempDir = sys_get_temp_dir().'/know-test-'.uniqid();
+            mkdir($tempDir, 0755, true);
+            $this->app->setBasePath($tempDir);
+
+            try {
+                $this->artisan('service:down', ['--odin' => true])
+                    ->assertFailed();
+            } finally {
+                rmdir($tempDir);
+            }
+        });
+    });
+
+    describe('docker compose execution', function () {
+        it('runs docker compose down successfully', function () {
+            $this->artisan('service:down')
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('docker', $process->command)
+                && in_array('down', $process->command));
+        });
+
+        it('runs docker compose down with volumes flag when forced', function () {
+            $this->artisan('service:down', ['--volumes' => true, '--force' => true])
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('docker', $process->command)
+                && in_array('-v', $process->command));
+        });
+
+        it('uses odin compose file when odin flag is set', function () {
+            $this->artisan('service:down', ['--odin' => true])
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('docker-compose.odin.yml', $process->command));
+        });
+
+        it('returns failure when docker compose fails', function () {
+            Process::fake([
+                '*docker*' => Process::result(
+                    errorOutput: 'Docker daemon not running',
+                    exitCode: 1,
+                ),
+            ]);
+
+            $this->artisan('service:down')
+                ->assertFailed();
+        });
+
+        it('combines odin and volumes flags correctly when forced', function () {
+            $this->artisan('service:down', ['--odin' => true, '--volumes' => true, '--force' => true])
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('docker-compose.odin.yml', $process->command)
+                && in_array('-v', $process->command));
+        });
+    });
+
+    describe('command signature', function () {
+        it('has correct command signature', function () {
+            $command = new \App\Commands\Service\DownCommand;
+            $reflection = new ReflectionClass($command);
+            $signatureProperty = $reflection->getProperty('signature');
+            $signatureProperty->setAccessible(true);
+            $signature = $signatureProperty->getValue($command);
+
+            expect($signature)->toContain('service:down');
+            expect($signature)->toContain('--volumes');
+            expect($signature)->toContain('--odin');
+            expect($signature)->toContain('--force');
+        });
+
+        it('has correct description', function () {
+            $command = new \App\Commands\Service\DownCommand;
+            $reflection = new ReflectionClass($command);
+            $descProperty = $reflection->getProperty('description');
+            $descProperty->setAccessible(true);
+            $description = $descProperty->getValue($command);
+
+            expect($description)->toBe('Stop knowledge services');
+        });
+    });
+});

--- a/tests/Feature/Commands/Service/LogsCommandTest.php
+++ b/tests/Feature/Commands/Service/LogsCommandTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Process;
+
+describe('service:logs command', function () {
+    beforeEach(function () {
+        // Fake all docker commands by default
+        Process::fake([
+            '*docker*' => Process::result(output: 'Logs output...', exitCode: 0),
+        ]);
+    });
+
+    describe('configuration file validation', function () {
+        it('fails when local docker-compose file does not exist', function () {
+            $tempDir = sys_get_temp_dir().'/know-test-'.uniqid();
+            mkdir($tempDir, 0755, true);
+            $this->app->setBasePath($tempDir);
+
+            try {
+                $this->artisan('service:logs', ['service' => 'qdrant'])
+                    ->assertFailed();
+            } finally {
+                rmdir($tempDir);
+            }
+        });
+
+        it('fails when odin docker-compose file does not exist', function () {
+            $tempDir = sys_get_temp_dir().'/know-test-'.uniqid();
+            mkdir($tempDir, 0755, true);
+            $this->app->setBasePath($tempDir);
+
+            try {
+                $this->artisan('service:logs', [
+                    'service' => 'qdrant',
+                    '--odin' => true,
+                ])
+                    ->assertFailed();
+            } finally {
+                rmdir($tempDir);
+            }
+        });
+    });
+
+    describe('docker compose execution', function () {
+        it('runs docker compose logs for specific service', function () {
+            $this->artisan('service:logs', ['service' => 'qdrant'])
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('docker', $process->command)
+                && in_array('logs', $process->command)
+                && in_array('qdrant', $process->command));
+        });
+
+        it('runs docker compose logs with follow flag', function () {
+            $this->artisan('service:logs', ['service' => 'qdrant', '--follow' => true])
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('docker', $process->command)
+                && in_array('-f', $process->command)
+                && in_array('logs', $process->command));
+        });
+
+        it('runs docker compose logs with custom tail count', function () {
+            $this->artisan('service:logs', ['service' => 'redis', '--tail' => 100])
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('--tail=100', $process->command));
+        });
+
+        it('uses odin compose file when odin flag is set', function () {
+            $this->artisan('service:logs', ['service' => 'qdrant', '--odin' => true])
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('docker-compose.odin.yml', $process->command));
+        });
+
+        it('returns exit code from docker compose', function () {
+            Process::fake([
+                '*docker*' => Process::result(
+                    errorOutput: 'Service not found',
+                    exitCode: 1,
+                ),
+            ]);
+
+            $this->artisan('service:logs', ['service' => 'nonexistent'])
+                ->assertExitCode(1);
+        });
+
+        it('combines follow and tail flags correctly', function () {
+            $this->artisan('service:logs', [
+                'service' => 'embeddings',
+                '--follow' => true,
+                '--tail' => 200,
+            ])
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('-f', $process->command)
+                && in_array('--tail=200', $process->command));
+        });
+
+        it('skips prompt when following without service', function () {
+            // When --follow is specified without a service, it doesn't prompt
+            $this->artisan('service:logs', ['--follow' => true])
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('-f', $process->command)
+                && in_array('logs', $process->command));
+        });
+    });
+
+    describe('command signature', function () {
+        it('has correct command signature', function () {
+            $command = new \App\Commands\Service\LogsCommand;
+            $reflection = new ReflectionClass($command);
+            $signatureProperty = $reflection->getProperty('signature');
+            $signatureProperty->setAccessible(true);
+            $signature = $signatureProperty->getValue($command);
+
+            expect($signature)->toContain('service:logs');
+            expect($signature)->toContain('{service?');
+            expect($signature)->toContain('--f|follow');
+            expect($signature)->toContain('--tail=50');
+            expect($signature)->toContain('--odin');
+        });
+
+        it('has correct description', function () {
+            $command = new \App\Commands\Service\LogsCommand;
+            $reflection = new ReflectionClass($command);
+            $descProperty = $reflection->getProperty('description');
+            $descProperty->setAccessible(true);
+            $description = $descProperty->getValue($command);
+
+            expect($description)->toBe('View service logs');
+        });
+
+        it('makes service argument optional', function () {
+            $command = new \App\Commands\Service\LogsCommand;
+            $reflection = new ReflectionClass($command);
+            $signatureProperty = $reflection->getProperty('signature');
+            $signatureProperty->setAccessible(true);
+            $signature = $signatureProperty->getValue($command);
+
+            expect($signature)->toContain('{service?');
+        });
+    });
+});

--- a/tests/Feature/Commands/Service/StatusCommandTest.php
+++ b/tests/Feature/Commands/Service/StatusCommandTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Contracts\HealthCheckInterface;
+use Illuminate\Support\Facades\Process;
+
+beforeEach(function () {
+    // Fake all docker commands by default
+    Process::fake([
+        '*docker*' => Process::result(output: '', exitCode: 0),
+    ]);
+
+    // Create a mock that returns fast, predictable responses
+    $healthCheck = mock(HealthCheckInterface::class);
+
+    $healthCheck->shouldReceive('checkAll')
+        ->andReturn([
+            ['name' => 'Qdrant', 'healthy' => true, 'endpoint' => 'localhost:6333', 'type' => 'Vector Database'],
+            ['name' => 'Redis', 'healthy' => false, 'endpoint' => '127.0.0.1:6380', 'type' => 'Cache'],
+            ['name' => 'Embeddings', 'healthy' => true, 'endpoint' => 'http://localhost:8001', 'type' => 'ML Service'],
+            ['name' => 'Ollama', 'healthy' => false, 'endpoint' => 'localhost:11434', 'type' => 'LLM Engine'],
+        ]);
+
+    $healthCheck->shouldReceive('getServices')
+        ->andReturn(['qdrant', 'redis', 'embeddings', 'ollama']);
+
+    $healthCheck->shouldReceive('check')
+        ->with('qdrant')
+        ->andReturn(['name' => 'Qdrant', 'healthy' => true, 'endpoint' => 'localhost:6333', 'type' => 'Vector Database']);
+
+    $healthCheck->shouldReceive('check')
+        ->with('redis')
+        ->andReturn(['name' => 'Redis', 'healthy' => false, 'endpoint' => '127.0.0.1:6380', 'type' => 'Cache']);
+
+    app()->instance(HealthCheckInterface::class, $healthCheck);
+});
+
+afterEach(function () {
+    Mockery::close();
+});
+
+describe('service:status command', function () {
+    describe('successful operations', function () {
+        it('always returns success exit code', function () {
+            $this->artisan('service:status')
+                ->assertSuccessful();
+        });
+
+        it('displays service status dashboard', function () {
+            $this->artisan('service:status')
+                ->assertSuccessful();
+        });
+
+        it('shows environment information', function () {
+            $this->artisan('service:status')
+                ->assertSuccessful();
+        });
+
+        it('shows odin environment with --odin flag', function () {
+            $this->artisan('service:status', ['--odin' => true])
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('docker-compose.odin.yml', $process->command));
+        });
+    });
+
+    describe('health checks via injected service', function () {
+        it('uses HealthCheckInterface for all service checks', function () {
+            $this->artisan('service:status')
+                ->assertSuccessful();
+        });
+
+        it('displays healthy services correctly', function () {
+            $healthCheck = mock(HealthCheckInterface::class);
+            $healthCheck->shouldReceive('checkAll')
+                ->andReturn([
+                    ['name' => 'Qdrant', 'healthy' => true, 'endpoint' => 'localhost:6333', 'type' => 'Vector Database'],
+                    ['name' => 'Redis', 'healthy' => true, 'endpoint' => 'localhost:6380', 'type' => 'Cache'],
+                ]);
+
+            app()->instance(HealthCheckInterface::class, $healthCheck);
+
+            $this->artisan('service:status')
+                ->assertSuccessful();
+        });
+
+        it('displays unhealthy services correctly', function () {
+            $healthCheck = mock(HealthCheckInterface::class);
+            $healthCheck->shouldReceive('checkAll')
+                ->andReturn([
+                    ['name' => 'Qdrant', 'healthy' => false, 'endpoint' => 'localhost:6333', 'type' => 'Vector Database'],
+                ]);
+
+            app()->instance(HealthCheckInterface::class, $healthCheck);
+
+            $this->artisan('service:status')
+                ->assertSuccessful();
+        });
+
+        it('handles partial outage scenario', function () {
+            $healthCheck = mock(HealthCheckInterface::class);
+            $healthCheck->shouldReceive('checkAll')
+                ->andReturn([
+                    ['name' => 'Qdrant', 'healthy' => true, 'endpoint' => 'localhost:6333', 'type' => 'Vector Database'],
+                    ['name' => 'Redis', 'healthy' => false, 'endpoint' => 'localhost:6380', 'type' => 'Cache'],
+                ]);
+
+            app()->instance(HealthCheckInterface::class, $healthCheck);
+
+            $this->artisan('service:status')
+                ->assertSuccessful();
+        });
+
+        it('handles major outage scenario', function () {
+            $healthCheck = mock(HealthCheckInterface::class);
+            $healthCheck->shouldReceive('checkAll')
+                ->andReturn([
+                    ['name' => 'Qdrant', 'healthy' => false, 'endpoint' => 'localhost:6333', 'type' => 'Vector Database'],
+                    ['name' => 'Redis', 'healthy' => false, 'endpoint' => 'localhost:6380', 'type' => 'Cache'],
+                ]);
+
+            app()->instance(HealthCheckInterface::class, $healthCheck);
+
+            $this->artisan('service:status')
+                ->assertSuccessful();
+        });
+    });
+
+    describe('container status via process', function () {
+        it('runs docker compose ps to get container status', function () {
+            Process::fake([
+                '*docker*' => Process::result(
+                    output: '{"Service":"qdrant","State":"running"}',
+                    exitCode: 0,
+                ),
+            ]);
+
+            $this->artisan('service:status')
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('docker', $process->command)
+                && in_array('ps', $process->command));
+        });
+
+        it('uses odin compose file with --odin flag', function () {
+            $this->artisan('service:status', ['--odin' => true])
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('docker-compose.odin.yml', $process->command));
+        });
+
+        it('handles docker compose failure gracefully', function () {
+            Process::fake([
+                '*docker*' => Process::result(
+                    errorOutput: 'Docker daemon not running',
+                    exitCode: 1,
+                ),
+            ]);
+
+            $this->artisan('service:status')
+                ->assertSuccessful(); // Command still succeeds, just no container info
+        });
+
+        it('displays running containers', function () {
+            Process::fake([
+                '*docker*' => Process::result(
+                    output: '{"Service":"qdrant","State":"running"}'."\n".'{"Service":"redis","State":"running"}',
+                    exitCode: 0,
+                ),
+            ]);
+
+            $this->artisan('service:status')
+                ->assertSuccessful();
+        });
+
+        it('displays container states correctly', function () {
+            Process::fake([
+                '*docker*' => Process::result(
+                    output: '{"Service":"qdrant","State":"running"}'."\n".'{"Service":"redis","State":"exited"}'."\n".'{"Service":"ollama","State":"paused"}',
+                    exitCode: 0,
+                ),
+            ]);
+
+            $this->artisan('service:status')
+                ->assertSuccessful();
+        });
+    });
+
+    describe('command signature', function () {
+        it('has correct command signature', function () {
+            $command = app(\App\Commands\Service\StatusCommand::class);
+            $reflection = new ReflectionClass($command);
+            $signatureProperty = $reflection->getProperty('signature');
+            $signatureProperty->setAccessible(true);
+            $signature = $signatureProperty->getValue($command);
+
+            expect($signature)->toContain('service:status');
+            expect($signature)->toContain('--odin');
+        });
+
+        it('has correct description', function () {
+            $command = app(\App\Commands\Service\StatusCommand::class);
+            $reflection = new ReflectionClass($command);
+            $descProperty = $reflection->getProperty('description');
+            $descProperty->setAccessible(true);
+            $description = $descProperty->getValue($command);
+
+            expect($description)->toBe('Check service health status');
+        });
+    });
+
+    describe('output formatting', function () {
+        it('displays service status sections', function () {
+            $this->artisan('service:status')
+                ->assertSuccessful();
+        });
+
+        it('displays tip about viewing logs', function () {
+            $this->artisan('service:status')
+                ->assertSuccessful();
+        });
+
+        it('shows service type for each service', function () {
+            $this->artisan('service:status')
+                ->assertSuccessful();
+        });
+    });
+
+    describe('process execution', function () {
+        it('is instance of Laravel Zero Command', function () {
+            $command = app(\App\Commands\Service\StatusCommand::class);
+
+            expect($command)->toBeInstanceOf(\LaravelZero\Framework\Commands\Command::class);
+        });
+    });
+
+    describe('container status handling', function () {
+        it('handles empty container list gracefully', function () {
+            Process::fake([
+                '*docker*' => Process::result(output: '', exitCode: 0),
+            ]);
+
+            $this->artisan('service:status')
+                ->assertSuccessful();
+        });
+    });
+});

--- a/tests/Feature/Commands/Service/UpCommandTest.php
+++ b/tests/Feature/Commands/Service/UpCommandTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Process;
+
+describe('service:up command', function () {
+    beforeEach(function () {
+        // Fake all docker commands by default
+        Process::fake([
+            '*docker*' => Process::result(output: 'OK', exitCode: 0),
+        ]);
+    });
+
+    describe('configuration file validation', function () {
+        it('fails when local docker-compose file does not exist', function () {
+            $tempDir = sys_get_temp_dir().'/know-test-'.uniqid();
+            mkdir($tempDir, 0755, true);
+            $this->app->setBasePath($tempDir);
+
+            try {
+                $this->artisan('service:up')
+                    ->assertFailed();
+            } finally {
+                rmdir($tempDir);
+            }
+        });
+
+        it('fails when odin docker-compose file does not exist', function () {
+            $tempDir = sys_get_temp_dir().'/know-test-'.uniqid();
+            mkdir($tempDir, 0755, true);
+            $this->app->setBasePath($tempDir);
+
+            try {
+                $this->artisan('service:up', ['--odin' => true])
+                    ->assertFailed();
+            } finally {
+                rmdir($tempDir);
+            }
+        });
+    });
+
+    describe('docker compose execution', function () {
+        it('runs docker compose up successfully', function () {
+            $this->artisan('service:up')
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('docker', $process->command)
+                && in_array('up', $process->command));
+        });
+
+        it('runs docker compose up with detach flag', function () {
+            $this->artisan('service:up', ['--detach' => true])
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('docker', $process->command)
+                && in_array('-d', $process->command));
+        });
+
+        it('uses odin compose file when odin flag is set', function () {
+            $this->artisan('service:up', ['--odin' => true])
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('docker-compose.odin.yml', $process->command));
+        });
+
+        it('returns failure when docker compose fails', function () {
+            Process::fake([
+                '*docker*' => Process::result(
+                    errorOutput: 'Docker daemon not running',
+                    exitCode: 1,
+                ),
+            ]);
+
+            $this->artisan('service:up')
+                ->assertFailed();
+        });
+
+        it('combines odin and detach flags correctly', function () {
+            $this->artisan('service:up', ['--odin' => true, '--detach' => true])
+                ->assertSuccessful();
+
+            Process::assertRan(fn ($process) => in_array('docker-compose.odin.yml', $process->command)
+                && in_array('-d', $process->command));
+        });
+    });
+
+    describe('command signature', function () {
+        it('has correct command signature', function () {
+            $command = new \App\Commands\Service\UpCommand;
+            $reflection = new ReflectionClass($command);
+            $signatureProperty = $reflection->getProperty('signature');
+            $signatureProperty->setAccessible(true);
+            $signature = $signatureProperty->getValue($command);
+
+            expect($signature)->toContain('service:up');
+            expect($signature)->toContain('--d|detach');
+            expect($signature)->toContain('--odin');
+        });
+
+        it('has correct description', function () {
+            $command = new \App\Commands\Service\UpCommand;
+            $reflection = new ReflectionClass($command);
+            $descProperty = $reflection->getProperty('description');
+            $descProperty->setAccessible(true);
+            $description = $descProperty->getValue($command);
+
+            expect($description)->toContain('Start knowledge services');
+        });
+    });
+});

--- a/tests/Unit/Services/HealthCheckServiceTest.php
+++ b/tests/Unit/Services/HealthCheckServiceTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\HealthCheckService;
+
+describe('HealthCheckService', function () {
+    it('returns all service keys', function () {
+        $service = new HealthCheckService;
+
+        $services = $service->getServices();
+
+        expect($services)->toBe(['qdrant', 'redis', 'embeddings', 'ollama']);
+    });
+
+    it('returns unhealthy status for unknown service', function () {
+        $service = new HealthCheckService;
+
+        $result = $service->check('nonexistent');
+
+        expect($result)->toBe([
+            'name' => 'nonexistent',
+            'healthy' => false,
+            'endpoint' => 'unknown',
+            'type' => 'Unknown',
+        ]);
+    });
+
+    it('checks all services and returns array', function () {
+        $service = new HealthCheckService;
+
+        $results = $service->checkAll();
+
+        expect($results)->toBeArray();
+        expect($results)->toHaveCount(4);
+
+        foreach ($results as $result) {
+            expect($result)->toHaveKeys(['name', 'healthy', 'endpoint', 'type']);
+            expect($result['healthy'])->toBeBool();
+            expect($result['name'])->toBeString();
+            expect($result['endpoint'])->toBeString();
+            expect($result['type'])->toBeString();
+        }
+    });
+
+    it('returns correct structure for qdrant check', function () {
+        $service = new HealthCheckService;
+
+        $result = $service->check('qdrant');
+
+        expect($result['name'])->toBe('Qdrant');
+        expect($result['type'])->toBe('Vector Database');
+        expect($result['healthy'])->toBeBool();
+        expect($result['endpoint'])->toBeString();
+    });
+
+    it('returns correct structure for redis check', function () {
+        $service = new HealthCheckService;
+
+        $result = $service->check('redis');
+
+        expect($result['name'])->toBe('Redis');
+        expect($result['type'])->toBe('Cache');
+        expect($result['healthy'])->toBeBool();
+        expect($result['endpoint'])->toBeString();
+    });
+
+    it('returns correct structure for embeddings check', function () {
+        $service = new HealthCheckService;
+
+        $result = $service->check('embeddings');
+
+        expect($result['name'])->toBe('Embeddings');
+        expect($result['type'])->toBe('ML Service');
+        expect($result['healthy'])->toBeBool();
+        expect($result['endpoint'])->toBeString();
+    });
+
+    it('returns correct structure for ollama check', function () {
+        $service = new HealthCheckService;
+
+        $result = $service->check('ollama');
+
+        expect($result['name'])->toBe('Ollama');
+        expect($result['type'])->toBe('LLM Engine');
+        expect($result['healthy'])->toBeBool();
+        expect($result['endpoint'])->toBeString();
+    });
+
+    it('uses config values for qdrant endpoint', function () {
+        config(['search.qdrant.host' => 'test-host']);
+        config(['search.qdrant.port' => 9999]);
+
+        $service = new HealthCheckService;
+        $result = $service->check('qdrant');
+
+        expect($result['endpoint'])->toBe('test-host:9999');
+    });
+
+    it('uses config values for redis endpoint', function () {
+        config(['database.redis.default.host' => 'redis-host']);
+        config(['database.redis.default.port' => 6380]);
+
+        $service = new HealthCheckService;
+        $result = $service->check('redis');
+
+        expect($result['endpoint'])->toBe('redis-host:6380');
+    });
+
+    it('uses config values for embeddings endpoint', function () {
+        config(['search.qdrant.embedding_server' => 'http://embed-host:8001']);
+
+        $service = new HealthCheckService;
+        $result = $service->check('embeddings');
+
+        expect($result['endpoint'])->toBe('http://embed-host:8001');
+    });
+
+    it('uses config values for ollama endpoint', function () {
+        config(['search.ollama.host' => 'ollama-host']);
+        config(['search.ollama.port' => 11434]);
+
+        $service = new HealthCheckService;
+        $result = $service->check('ollama');
+
+        expect($result['endpoint'])->toBe('ollama-host:11434');
+    });
+
+    it('checkAll returns same count as getServices', function () {
+        $service = new HealthCheckService;
+
+        $services = $service->getServices();
+        $results = $service->checkAll();
+
+        expect(count($results))->toBe(count($services));
+    });
+});


### PR DESCRIPTION
## Summary
- Restore service commands (up/down/status/logs) that were removed during cleanup
- Replace all unsupported Termwind flexbox classes (`flex`, `justify-between`, `items-center`, `space-y-*`, `text-right`) with stacked `<div>` layouts using supported classes (`mx-*`, `my-*`, `px-*`, `py-*`, `mb-*`, `mt-*`, `ml-*`)
- Restore `HealthCheckInterface`, `HealthCheckService`, and provider binding
- Add parallel-safe tests (use temp dir instead of file renames to avoid race conditions)

Closes #84

## Changes
| File | Description |
|------|-------------|
| `app/Commands/Service/StatusCommand.php` | Health dashboard with stacked div layout |
| `app/Commands/Service/UpCommand.php` | Start services with fixed banners |
| `app/Commands/Service/DownCommand.php` | Stop services with fixed alerts |
| `app/Commands/Service/LogsCommand.php` | View logs with fixed header layout |
| `app/Contracts/HealthCheckInterface.php` | Restored contract |
| `app/Services/HealthCheckService.php` | Restored health check service |
| `app/Providers/AppServiceProvider.php` | Added HealthCheckInterface binding |
| `tests/` | 63 new tests across 5 test files |

## Termwind Classes Fixed
| Unsupported (removed) | Replacement |
|----------------------|-------------|
| `flex` | Stacked `<div>` elements |
| `justify-between` | Inline `<span>` with `ml-*` spacing |
| `items-center` | Removed (not needed with stacked layout) |
| `space-y-*` | Individual `mb-1` on each child div |
| `text-right` | Removed (content flows inline) |

## Test plan
- [x] All 705 tests pass in parallel mode
- [x] PHPStan level 8 passes clean
- [x] Laravel Pint formatting applied
- [x] Service commands render without Termwind style errors
- [x] Parallel-safe tests (no file rename race conditions)