### PR TITLE
feat: add Odin background sync for centralized server

### DIFF
--- a/app/Commands/OdinSyncCommand.php
+++ b/app/Commands/OdinSyncCommand.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands;
+
+use App\Services\OdinSyncService;
+use App\Services\QdrantService;
+use Illuminate\Support\Str;
+use LaravelZero\Framework\Commands\Command;
+
+class OdinSyncCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'sync:odin
+                            {--push : Push queued entries to Odin}
+                            {--pull : Pull entries from Odin}
+                            {--status : Show sync status only}
+                            {--clear : Clear the sync queue}
+                            {--project=default : Project namespace to sync}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Synchronize knowledge with Odin centralized server';
+
+    public function handle(OdinSyncService $odinSync, QdrantService $qdrant): int
+    {
+        if (! $odinSync->isEnabled()) {
+            $this->error('Odin sync is disabled. Set ODIN_SYNC_ENABLED=true to enable.');
+
+            return self::FAILURE;
+        }
+
+        // Status-only mode
+        if ((bool) $this->option('status')) {
+            $this->displayStatus($odinSync);
+
+            return self::SUCCESS;
+        }
+
+        // Clear queue
+        if ((bool) $this->option('clear')) {
+            $odinSync->clearQueue();
+            $this->info('Sync queue cleared.');
+
+            return self::SUCCESS;
+        }
+
+        $push = (bool) $this->option('push');
+        $pull = (bool) $this->option('pull');
+        /** @var string $project */
+        $project = $this->option('project');
+
+        // Default: push then pull
+        if (! $push && ! $pull) {
+            $push = true;
+            $pull = true;
+        }
+
+        // Check connectivity
+        $this->line('Checking Odin connectivity...');
+        $available = $odinSync->isAvailable();
+
+        if (! $available) {
+            $this->warn('Odin server is not reachable. Operations will remain queued for later sync.');
+
+            $status = $odinSync->getStatus();
+            $this->line("Pending operations: {$status['pending']}");
+
+            return self::SUCCESS;
+        }
+
+        $this->info('Odin server connected.');
+
+        $pushResult = ['synced' => 0, 'failed' => 0, 'remaining' => 0];
+        $pullCount = 0;
+
+        // Push queued items
+        if ($push) {
+            $this->line('Processing sync queue...');
+            $pushResult = $odinSync->processQueue();
+        }
+
+        // Pull from Odin
+        if ($pull) {
+            $this->line("Pulling entries from Odin for project '{$project}'...");
+            $entries = $odinSync->pullFromOdin($project);
+            $pullCount = $this->mergeEntries($entries, $qdrant, $odinSync, $project);
+        }
+
+        $this->displaySyncSummary($pushResult, $pullCount, $pull);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Merge pulled entries into local Qdrant using last-write-wins.
+     *
+     * @param  array<int, array<string, mixed>>  $remoteEntries
+     */
+    private function mergeEntries(
+        array $remoteEntries,
+        QdrantService $qdrant,
+        OdinSyncService $odinSync,
+        string $project,
+    ): int {
+        $merged = 0;
+
+        foreach ($remoteEntries as $remote) {
+            $title = $remote['title'] ?? '';
+            if ($title === '') {
+                continue;
+            }
+
+            // Search for existing local entry by title
+            $existing = $qdrant->search($title, [], 1, $project);
+            $local = $existing->first();
+
+            if ($local !== null) {
+                // Conflict resolution: last-write-wins
+                $winner = $odinSync->resolveConflict($local, $remote);
+                if ($winner === $remote) {
+                    $entry = $this->buildEntryFromRemote($remote, $local['id']);
+                    $qdrant->upsert($entry, $project);
+                    $merged++;
+                }
+            } else {
+                // New entry from Odin
+                $entry = $this->buildEntryFromRemote($remote, Str::uuid()->toString());
+                $qdrant->upsert($entry, $project);
+                $merged++;
+            }
+        }
+
+        return $merged;
+    }
+
+    /**
+     * Build a local entry from remote data.
+     *
+     * @param  array<string, mixed>  $remote
+     * @return array{id: string|int, title: string, content: string, tags: array<string>, category?: string, module?: string, priority: string, status: string, confidence: int, usage_count: int, created_at: string, updated_at: string}
+     */
+    private function buildEntryFromRemote(array $remote, string|int $id): array
+    {
+        /** @var array<string> $tags */
+        $tags = $remote['tags'] ?? [];
+
+        $entry = [
+            'id' => $id,
+            'title' => (string) ($remote['title'] ?? 'Untitled'),
+            'content' => (string) ($remote['content'] ?? ''),
+            'tags' => $tags,
+            'priority' => (string) ($remote['priority'] ?? 'medium'),
+            'confidence' => (int) ($remote['confidence'] ?? 50),
+            'status' => (string) ($remote['status'] ?? 'draft'),
+            'usage_count' => (int) ($remote['usage_count'] ?? 0),
+            'created_at' => (string) ($remote['created_at'] ?? now()->toIso8601String()),
+            'updated_at' => (string) ($remote['updated_at'] ?? now()->toIso8601String()),
+        ];
+
+        if (isset($remote['category']) && is_string($remote['category'])) {
+            $entry['category'] = $remote['category'];
+        }
+
+        if (isset($remote['module']) && is_string($remote['module'])) {
+            $entry['module'] = $remote['module'];
+        }
+
+        return $entry;
+    }
+
+    private function displayStatus(OdinSyncService $odinSync): void
+    {
+        $status = $odinSync->getStatus();
+
+        $statusColor = match ($status['status']) {
+            'synced' => 'green',
+            'error' => 'red',
+            'pending', 'partial' => 'yellow',
+            default => 'gray',
+        };
+
+        $this->newLine();
+        $this->line('<fg=gray>Odin Sync Status</>');
+        $this->table(
+            ['Property', 'Value'],
+            [
+                ['Status', "<fg={$statusColor}>{$status['status']}</>"],
+                ['Pending Operations', (string) $status['pending']],
+                ['Last Synced', $status['last_synced'] ?? 'Never'],
+                ['Last Error', $status['last_error'] ?? 'None'],
+                ['Odin URL', (string) config('services.odin.url', 'Not configured')],
+            ]
+        );
+    }
+
+    /**
+     * @param  array{synced: int, failed: int, remaining: int}  $pushResult
+     */
+    private function displaySyncSummary(array $pushResult, int $pullCount, bool $pulled): void
+    {
+        $this->newLine();
+        $this->info('=== Odin Sync Summary ===');
+
+        $rows = [
+            ['Pushed (synced)', (string) $pushResult['synced']],
+            ['Push failures', (string) $pushResult['failed']],
+            ['Remaining in queue', (string) $pushResult['remaining']],
+        ];
+
+        if ($pulled) {
+            $rows[] = ['Pulled & merged', (string) $pullCount];
+        }
+
+        $this->table(['Operation', 'Count'], $rows);
+    }
+}

--- a/app/Commands/ProjectsCommand.php
+++ b/app/Commands/ProjectsCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands;
+
+use App\Services\OdinSyncService;
+use LaravelZero\Framework\Commands\Command;
+
+class ProjectsCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'projects
+                            {--local : Show only local project collections}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'List synced knowledge base projects from Odin';
+
+    public function handle(OdinSyncService $odinSync): int
+    {
+        if ((bool) $this->option('local')) {
+            $this->info('Local project listing requires Qdrant collection enumeration.');
+            $this->line('Use "know stats" to see current project statistics.');
+
+            return self::SUCCESS;
+        }
+
+        if (! $odinSync->isEnabled()) {
+            $this->error('Odin sync is disabled. Set ODIN_SYNC_ENABLED=true to enable.');
+
+            return self::FAILURE;
+        }
+
+        $this->line('Fetching projects from Odin...');
+
+        if (! $odinSync->isAvailable()) {
+            $this->warn('Odin server is not reachable. Cannot list remote projects.');
+
+            return self::SUCCESS;
+        }
+
+        $projects = $odinSync->listProjects();
+
+        if ($projects === []) {
+            $this->info('No projects found on Odin server.');
+
+            return self::SUCCESS;
+        }
+
+        $rows = [];
+        foreach ($projects as $project) {
+            $rows[] = [
+                $project['name'],
+                (string) $project['entry_count'],
+                $project['last_synced'] ?? 'Never',
+            ];
+        }
+
+        $this->table(['Project', 'Entries', 'Last Synced'], $rows);
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Contracts\EmbeddingServiceInterface;
 use App\Services\KnowledgeCacheService;
 use App\Services\KnowledgePathService;
+use App\Services\OdinSyncService;
 use App\Services\QdrantService;
 use App\Services\RuntimeEnvironment;
 use App\Services\StubEmbeddingService;
@@ -123,6 +124,11 @@ class AppServiceProvider extends ServiceProvider
             (int) config('search.qdrant.cache_ttl', 604800),
             (bool) config('search.qdrant.secure', false),
             cacheService: $app->make(KnowledgeCacheService::class)
+        ));
+
+        // Odin sync service
+        $this->app->singleton(OdinSyncService::class, fn ($app): \App\Services\OdinSyncService => new OdinSyncService(
+            $app->make(KnowledgePathService::class)
         ));
     }
 }

--- a/app/Services/OdinSyncService.php
+++ b/app/Services/OdinSyncService.php
@@ -1,0 +1,535 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+
+class OdinSyncService
+{
+    private readonly string $queuePath;
+
+    private readonly string $statusPath;
+
+    protected ?Client $client = null;
+
+    public function __construct(
+        private readonly KnowledgePathService $pathService,
+    ) {
+        $knowledgeDir = $this->pathService->getKnowledgeDirectory();
+        $this->queuePath = $knowledgeDir.'/sync_queue.json';
+        $this->statusPath = $knowledgeDir.'/sync_status.json';
+    }
+
+    /**
+     * Check if Odin sync is enabled in configuration.
+     */
+    public function isEnabled(): bool
+    {
+        return (bool) config('services.odin.enabled', true);
+    }
+
+    /**
+     * Check connectivity to Odin server.
+     */
+    public function isAvailable(): bool
+    {
+        $url = $this->getBaseUrl();
+        $token = $this->getToken();
+
+        if ($url === '' || $token === '') {
+            return false;
+        }
+
+        try {
+            $response = $this->getClient()->get('/api/knowledge/entries', [
+                'headers' => [
+                    'Authorization' => "Bearer {$token}",
+                    'Accept' => 'application/json',
+                ],
+                'query' => ['per_page' => 1],
+                'timeout' => 5,
+            ]);
+
+            return $response->getStatusCode() === 200;
+        } catch (GuzzleException) {
+            return false;
+        }
+    }
+
+    /**
+     * Queue an entry for sync to Odin.
+     *
+     * @param  array<string, mixed>  $entry
+     */
+    public function queueForSync(array $entry, string $operation = 'upsert', string $project = 'default'): void
+    {
+        if (! $this->isEnabled()) {
+            return;
+        }
+
+        $queue = $this->loadQueue();
+
+        $queue[] = [
+            'operation' => $operation,
+            'project' => $project,
+            'entry' => $entry,
+            'queued_at' => now()->toIso8601String(),
+        ];
+
+        $this->saveQueue($queue);
+    }
+
+    /**
+     * Process the sync queue, pushing pending items to Odin.
+     *
+     * @return array{synced: int, failed: int, remaining: int}
+     */
+    public function processQueue(): array
+    {
+        $queue = $this->loadQueue();
+        $synced = 0;
+        $failed = 0;
+
+        if ($queue === []) {
+            $this->updateStatus('idle', 0);
+
+            return ['synced' => 0, 'failed' => 0, 'remaining' => 0];
+        }
+
+        $token = $this->getToken();
+        if ($token === '') {
+            return ['synced' => 0, 'failed' => 0, 'remaining' => count($queue)];
+        }
+
+        $remaining = [];
+        $batchSize = max(1, (int) config('services.odin.batch_size', 50));
+        $batches = array_chunk($queue, $batchSize);
+
+        foreach ($batches as $batch) {
+            $upserts = [];
+            $deletes = [];
+
+            foreach ($batch as $item) {
+                if ($item['operation'] === 'delete') {
+                    $deletes[] = $item;
+                } else {
+                    $upserts[] = $item;
+                }
+            }
+
+            if ($upserts !== []) {
+                $result = $this->pushBatch($token, $upserts);
+                $synced += $result['synced'];
+                $failed += $result['failed'];
+                foreach ($result['failedItems'] as $failedItem) {
+                    $remaining[] = $failedItem;
+                }
+            }
+
+            if ($deletes !== []) {
+                $result = $this->deleteBatch($token, $deletes);
+                $synced += $result['synced'];
+                $failed += $result['failed'];
+                foreach ($result['failedItems'] as $failedItem) {
+                    $remaining[] = $failedItem;
+                }
+            }
+        }
+
+        $this->saveQueue($remaining);
+        $this->updateStatus($remaining === [] ? 'synced' : 'partial', count($remaining));
+
+        return ['synced' => $synced, 'failed' => $failed, 'remaining' => count($remaining)];
+    }
+
+    /**
+     * Pull fresh entries from Odin for a project.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function pullFromOdin(string $project = 'default'): array
+    {
+        $token = $this->getToken();
+        if ($token === '') {
+            return [];
+        }
+
+        try {
+            $response = $this->getClient()->get('/api/knowledge/entries', [
+                'headers' => [
+                    'Authorization' => "Bearer {$token}",
+                    'Accept' => 'application/json',
+                ],
+                'query' => ['project' => $project],
+            ]);
+
+            if ($response->getStatusCode() !== 200) {
+                return [];
+            }
+
+            $data = json_decode((string) $response->getBody(), true);
+            if (! is_array($data) || ! isset($data['data'])) {
+                return [];
+            }
+
+            /** @var array<int, array<string, mixed>> */
+            return $data['data'];
+        } catch (GuzzleException) {
+            return [];
+        }
+    }
+
+    /**
+     * List all projects that have been synced to Odin.
+     *
+     * @return array<int, array{name: string, entry_count: int, last_synced: string|null}>
+     */
+    public function listProjects(): array
+    {
+        $token = $this->getToken();
+        if ($token === '') {
+            return [];
+        }
+
+        try {
+            $response = $this->getClient()->get('/api/knowledge/projects', [
+                'headers' => [
+                    'Authorization' => "Bearer {$token}",
+                    'Accept' => 'application/json',
+                ],
+            ]);
+
+            if ($response->getStatusCode() !== 200) {
+                return [];
+            }
+
+            $data = json_decode((string) $response->getBody(), true);
+            if (! is_array($data) || ! isset($data['data'])) {
+                return [];
+            }
+
+            /** @var array<int, array{name: string, entry_count: int, last_synced: string|null}> */
+            return $data['data'];
+        } catch (GuzzleException) {
+            return [];
+        }
+    }
+
+    /**
+     * Get the current sync status.
+     *
+     * @return array{status: string, pending: int, last_synced: string|null, last_error: string|null}
+     */
+    public function getStatus(): array
+    {
+        $default = [
+            'status' => 'idle',
+            'pending' => 0,
+            'last_synced' => null,
+            'last_error' => null,
+        ];
+
+        if (! file_exists($this->statusPath)) {
+            $queue = $this->loadQueue();
+            $default['pending'] = count($queue);
+            $default['status'] = $queue !== [] ? 'pending' : 'idle';
+
+            return $default;
+        }
+
+        $content = file_get_contents($this->statusPath);
+        if ($content === false) {
+            return $default;
+        }
+
+        $status = json_decode($content, true);
+        if (! is_array($status)) {
+            return $default;
+        }
+
+        // Always refresh the pending count from the actual queue
+        $queue = $this->loadQueue();
+        $status['pending'] = count($queue);
+        if ($queue !== [] && $status['status'] === 'idle') {
+            $status['status'] = 'pending';
+        }
+
+        /** @var int $pendingCount */
+        $pendingCount = $status['pending'];
+
+        return [
+            'status' => $status['status'] ?? 'idle',
+            'pending' => $pendingCount,
+            'last_synced' => $status['last_synced'] ?? null,
+            'last_error' => $status['last_error'] ?? null,
+        ];
+    }
+
+    /**
+     * Get the pending queue count.
+     */
+    public function getPendingCount(): int
+    {
+        return count($this->loadQueue());
+    }
+
+    /**
+     * Resolve conflicts using last-write-wins strategy.
+     *
+     * @param  array<string, mixed>  $local
+     * @param  array<string, mixed>  $remote
+     * @return array<string, mixed>
+     */
+    public function resolveConflict(array $local, array $remote): array
+    {
+        $localTime = $local['updated_at'] ?? '';
+        $remoteTime = $remote['updated_at'] ?? '';
+
+        if ($localTime === '' && $remoteTime === '') {
+            return $local;
+        }
+
+        if ($localTime === '') {
+            return $remote;
+        }
+
+        if ($remoteTime === '') {
+            return $local;
+        }
+
+        return strtotime($localTime) >= strtotime($remoteTime) ? $local : $remote;
+    }
+
+    /**
+     * Clear the sync queue.
+     */
+    public function clearQueue(): void
+    {
+        $this->saveQueue([]);
+        $this->updateStatus('idle', 0);
+    }
+
+    /**
+     * Push a batch of entries to Odin.
+     *
+     * @param  array<int, array<string, mixed>>  $items
+     * @return array{synced: int, failed: int, failedItems: array<int, array<string, mixed>>}
+     */
+    private function pushBatch(string $token, array $items): array
+    {
+        $synced = 0;
+        $failed = 0;
+        $failedItems = [];
+
+        $payload = [];
+        foreach ($items as $item) {
+            $entry = $item['entry'];
+            $payload[] = [
+                'unique_id' => $this->generateUniqueId($entry),
+                'title' => mb_substr((string) ($entry['title'] ?? ''), 0, 255),
+                'content' => $entry['content'] ?? '',
+                'category' => $entry['category'] ?? null,
+                'tags' => $entry['tags'] ?? [],
+                'module' => $entry['module'] ?? null,
+                'priority' => $entry['priority'] ?? null,
+                'confidence' => $entry['confidence'] ?? 0,
+                'status' => $entry['status'] ?? null,
+                'project' => $item['project'] ?? 'default',
+                'source' => null,
+                'ticket' => null,
+                'files' => [],
+                'repo' => null,
+                'branch' => null,
+                'commit' => null,
+                'author' => null,
+            ];
+        }
+
+        try {
+            $response = $this->getClient()->post('/api/knowledge/sync', [
+                'headers' => [
+                    'Authorization' => "Bearer {$token}",
+                    'Accept' => 'application/json',
+                    'Content-Type' => 'application/json',
+                ],
+                'json' => ['entries' => $payload],
+            ]);
+
+            if ($response->getStatusCode() === 200) {
+                $synced = count($items);
+                $this->updateStatus('synced', 0, now()->toIso8601String());
+            } else {
+                $failed = count($items);
+                $failedItems = $items;
+                $this->updateStatus('error', count($items), null, 'HTTP '.$response->getStatusCode());
+            }
+        } catch (GuzzleException $e) {
+            $failed = count($items);
+            $failedItems = $items;
+            $this->updateStatus('error', count($items), null, $e->getMessage());
+        }
+
+        return ['synced' => $synced, 'failed' => $failed, 'failedItems' => $failedItems];
+    }
+
+    /**
+     * Delete a batch of entries from Odin.
+     *
+     * @param  array<int, array<string, mixed>>  $items
+     * @return array{synced: int, failed: int, failedItems: array<int, array<string, mixed>>}
+     */
+    private function deleteBatch(string $token, array $items): array
+    {
+        $synced = 0;
+        $failed = 0;
+        $failedItems = [];
+
+        foreach ($items as $item) {
+            $entry = $item['entry'];
+            $uniqueId = $this->generateUniqueId($entry);
+
+            try {
+                $response = $this->getClient()->delete("/api/knowledge/by-unique-id/{$uniqueId}", [
+                    'headers' => [
+                        'Authorization' => "Bearer {$token}",
+                        'Accept' => 'application/json',
+                    ],
+                ]);
+
+                if ($response->getStatusCode() >= 200 && $response->getStatusCode() < 300) {
+                    $synced++;
+                } else {
+                    $failed++;
+                    $failedItems[] = $item;
+                }
+            } catch (GuzzleException) {
+                $failed++;
+                $failedItems[] = $item;
+            }
+        }
+
+        return ['synced' => $synced, 'failed' => $failed, 'failedItems' => $failedItems];
+    }
+
+    /**
+     * Generate unique ID for an entry.
+     *
+     * @param  array<string, mixed>  $entry
+     */
+    private function generateUniqueId(array $entry): string
+    {
+        return hash('sha256', ($entry['id'] ?? '').'-'.($entry['title'] ?? ''));
+    }
+
+    /**
+     * Load the sync queue from disk.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function loadQueue(): array
+    {
+        if (! file_exists($this->queuePath)) {
+            return [];
+        }
+
+        $content = file_get_contents($this->queuePath);
+        if ($content === false) {
+            return [];
+        }
+
+        $data = json_decode($content, true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * Save the sync queue to disk.
+     *
+     * @param  array<int, array<string, mixed>>  $queue
+     */
+    private function saveQueue(array $queue): void
+    {
+        $dir = dirname($this->queuePath);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        file_put_contents($this->queuePath, json_encode($queue, JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * Update the sync status file.
+     */
+    private function updateStatus(string $status, int $pending, ?string $lastSynced = null, ?string $lastError = null): void
+    {
+        $current = $this->getStatus();
+
+        $data = [
+            'status' => $status,
+            'pending' => $pending,
+            'last_synced' => $lastSynced ?? $current['last_synced'],
+            'last_error' => $lastError,
+        ];
+
+        $dir = dirname($this->statusPath);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        file_put_contents($this->statusPath, json_encode($data, JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * Get the Odin API base URL.
+     */
+    private function getBaseUrl(): string
+    {
+        $url = config('services.odin.url', '');
+
+        return is_string($url) ? $url : '';
+    }
+
+    /**
+     * Get the Odin API token.
+     */
+    private function getToken(): string
+    {
+        $token = config('services.odin.token', '');
+
+        return is_string($token) ? $token : '';
+    }
+
+    /**
+     * Get or create HTTP client.
+     */
+    protected function getClient(): Client
+    {
+        if (! $this->client instanceof Client) {
+            $this->client = app()->bound(Client::class)
+                ? app(Client::class)
+                : $this->createClient();
+        }
+
+        return $this->client;
+    }
+
+    /**
+     * Create a new HTTP client instance.
+     *
+     * @codeCoverageIgnore HTTP client factory - tested via integration
+     */
+    protected function createClient(): Client
+    {
+        return new Client([
+            'base_uri' => $this->getBaseUrl(),
+            'timeout' => (int) config('services.odin.timeout', 10),
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+            ],
+        ]);
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -17,4 +17,23 @@ return [
         'token' => env('PREFRONTAL_API_TOKEN'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Odin Sync Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for background sync with the Odin centralized Qdrant
+    | server. Operations are queued locally and synced when Odin is available.
+    | Last-write-wins conflict resolution based on updated_at timestamps.
+    |
+    */
+
+    'odin' => [
+        'enabled' => env('ODIN_SYNC_ENABLED', true),
+        'url' => env('ODIN_URL', 'http://100.68.122.24:8080'),
+        'token' => env('ODIN_API_TOKEN', env('PREFRONTAL_API_TOKEN')),
+        'timeout' => env('ODIN_TIMEOUT', 10),
+        'batch_size' => env('ODIN_BATCH_SIZE', 50),
+    ],
+
 ];

--- a/tests/Feature/Commands/OdinSyncCommandTest.php
+++ b/tests/Feature/Commands/OdinSyncCommandTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\OdinSyncService;
+use App\Services\QdrantService;
+
+beforeEach(function (): void {
+    $this->odinMock = Mockery::mock(OdinSyncService::class);
+    $this->qdrantMock = Mockery::mock(QdrantService::class);
+    $this->app->instance(OdinSyncService::class, $this->odinMock);
+    $this->app->instance(QdrantService::class, $this->qdrantMock);
+});
+
+describe('OdinSyncCommand basic', function (): void {
+    it('fails when odin sync is disabled', function (): void {
+        $this->odinMock->shouldReceive('isEnabled')->once()->andReturn(false);
+
+        $this->artisan('sync:odin')
+            ->assertFailed()
+            ->expectsOutput('Odin sync is disabled. Set ODIN_SYNC_ENABLED=true to enable.');
+    });
+
+    it('shows status only with --status flag', function (): void {
+        $this->odinMock->shouldReceive('isEnabled')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('getStatus')->once()->andReturn([
+            'status' => 'synced',
+            'pending' => 0,
+            'last_synced' => '2025-06-01T12:00:00+00:00',
+            'last_error' => null,
+        ]);
+
+        config(['services.odin.url' => 'http://odin.local']);
+
+        $this->artisan('sync:odin', ['--status' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Odin Sync Status');
+    });
+
+    it('clears queue with --clear flag', function (): void {
+        $this->odinMock->shouldReceive('isEnabled')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('clearQueue')->once();
+
+        $this->artisan('sync:odin', ['--clear' => true])
+            ->assertSuccessful()
+            ->expectsOutput('Sync queue cleared.');
+    });
+});
+
+describe('OdinSyncCommand connectivity', function (): void {
+    it('warns when Odin is unreachable', function (): void {
+        $this->odinMock->shouldReceive('isEnabled')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('isAvailable')->once()->andReturn(false);
+        $this->odinMock->shouldReceive('getStatus')->once()->andReturn([
+            'status' => 'pending',
+            'pending' => 3,
+            'last_synced' => null,
+            'last_error' => null,
+        ]);
+
+        $this->artisan('sync:odin')
+            ->assertSuccessful()
+            ->expectsOutputToContain('Odin server is not reachable')
+            ->expectsOutputToContain('Pending operations: 3');
+    });
+});
+
+describe('OdinSyncCommand push', function (): void {
+    it('pushes queued items when --push is specified', function (): void {
+        $this->odinMock->shouldReceive('isEnabled')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('isAvailable')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('processQueue')->once()->andReturn([
+            'synced' => 5,
+            'failed' => 0,
+            'remaining' => 0,
+        ]);
+
+        $this->artisan('sync:odin', ['--push' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Odin Sync Summary');
+    });
+});
+
+describe('OdinSyncCommand pull', function (): void {
+    it('pulls and merges entries when --pull is specified', function (): void {
+        $this->odinMock->shouldReceive('isEnabled')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('isAvailable')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('pullFromOdin')
+            ->once()
+            ->with('default')
+            ->andReturn([
+                [
+                    'title' => 'Remote Entry',
+                    'content' => 'Remote content',
+                    'updated_at' => '2025-06-01T12:00:00+00:00',
+                    'category' => null,
+                    'tags' => [],
+                    'module' => null,
+                    'priority' => 'medium',
+                    'confidence' => 50,
+                    'status' => 'draft',
+                    'usage_count' => 0,
+                ],
+            ]);
+
+        // No local match found
+        $this->qdrantMock->shouldReceive('search')
+            ->once()
+            ->with('Remote Entry', [], 1, 'default')
+            ->andReturn(collect());
+
+        // Upsert the new entry
+        $this->qdrantMock->shouldReceive('upsert')
+            ->once()
+            ->andReturn(true);
+
+        $this->odinMock->shouldNotReceive('resolveConflict');
+
+        $this->artisan('sync:odin', ['--pull' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Odin Sync Summary');
+    });
+
+    it('resolves conflicts with last-write-wins on pull', function (): void {
+        $localEntry = [
+            'id' => 'local-1',
+            'title' => 'Shared Entry',
+            'content' => 'Local content',
+            'updated_at' => '2025-05-01T12:00:00+00:00',
+        ];
+
+        $remoteEntry = [
+            'title' => 'Shared Entry',
+            'content' => 'Remote content (newer)',
+            'updated_at' => '2025-06-01T12:00:00+00:00',
+            'category' => null,
+            'tags' => [],
+            'module' => null,
+            'priority' => 'medium',
+            'confidence' => 50,
+            'status' => 'draft',
+            'usage_count' => 0,
+        ];
+
+        $this->odinMock->shouldReceive('isEnabled')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('isAvailable')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('pullFromOdin')
+            ->once()
+            ->with('default')
+            ->andReturn([$remoteEntry]);
+
+        $this->qdrantMock->shouldReceive('search')
+            ->once()
+            ->with('Shared Entry', [], 1, 'default')
+            ->andReturn(collect([$localEntry]));
+
+        // Remote is newer, should win
+        $this->odinMock->shouldReceive('resolveConflict')
+            ->once()
+            ->with($localEntry, $remoteEntry)
+            ->andReturn($remoteEntry);
+
+        $this->qdrantMock->shouldReceive('upsert')
+            ->once()
+            ->andReturn(true);
+
+        $this->artisan('sync:odin', ['--pull' => true])
+            ->assertSuccessful();
+    });
+
+    it('skips entries with empty title on pull', function (): void {
+        $this->odinMock->shouldReceive('isEnabled')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('isAvailable')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('pullFromOdin')
+            ->once()
+            ->andReturn([
+                ['title' => '', 'content' => 'No title'],
+            ]);
+
+        $this->qdrantMock->shouldNotReceive('search');
+        $this->qdrantMock->shouldNotReceive('upsert');
+
+        $this->artisan('sync:odin', ['--pull' => true])
+            ->assertSuccessful();
+    });
+
+    it('skips update when local wins conflict', function (): void {
+        $localEntry = [
+            'id' => 'local-1',
+            'title' => 'Shared Entry',
+            'content' => 'Local content (newer)',
+            'updated_at' => '2025-06-01T12:00:00+00:00',
+        ];
+
+        $remoteEntry = [
+            'title' => 'Shared Entry',
+            'content' => 'Remote content (older)',
+            'updated_at' => '2025-05-01T12:00:00+00:00',
+        ];
+
+        $this->odinMock->shouldReceive('isEnabled')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('isAvailable')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('pullFromOdin')
+            ->once()
+            ->andReturn([$remoteEntry]);
+
+        $this->qdrantMock->shouldReceive('search')
+            ->once()
+            ->andReturn(collect([$localEntry]));
+
+        // Local wins
+        $this->odinMock->shouldReceive('resolveConflict')
+            ->once()
+            ->andReturn($localEntry);
+
+        // Should NOT upsert since local wins
+        $this->qdrantMock->shouldNotReceive('upsert');
+
+        $this->artisan('sync:odin', ['--pull' => true])
+            ->assertSuccessful();
+    });
+});
+
+describe('OdinSyncCommand default two-way sync', function (): void {
+    it('performs push then pull with no flags', function (): void {
+        $this->odinMock->shouldReceive('isEnabled')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('isAvailable')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('processQueue')->once()->andReturn([
+            'synced' => 2,
+            'failed' => 0,
+            'remaining' => 0,
+        ]);
+        $this->odinMock->shouldReceive('pullFromOdin')
+            ->once()
+            ->with('default')
+            ->andReturn([]);
+
+        $this->artisan('sync:odin')
+            ->assertSuccessful()
+            ->expectsOutputToContain('Odin Sync Summary');
+    });
+
+    it('accepts custom project option', function (): void {
+        $this->odinMock->shouldReceive('isEnabled')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('isAvailable')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('processQueue')->once()->andReturn([
+            'synced' => 0,
+            'failed' => 0,
+            'remaining' => 0,
+        ]);
+        $this->odinMock->shouldReceive('pullFromOdin')
+            ->once()
+            ->with('custom-project')
+            ->andReturn([]);
+
+        $this->artisan('sync:odin', ['--project' => 'custom-project'])
+            ->assertSuccessful();
+    });
+});

--- a/tests/Feature/Commands/ProjectsCommandTest.php
+++ b/tests/Feature/Commands/ProjectsCommandTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\OdinSyncService;
+
+beforeEach(function (): void {
+    $this->odinMock = Mockery::mock(OdinSyncService::class);
+    $this->app->instance(OdinSyncService::class, $this->odinMock);
+});
+
+describe('ProjectsCommand', function (): void {
+    it('shows local info when --local flag is used', function (): void {
+        $this->artisan('projects', ['--local' => true])
+            ->assertSuccessful()
+            ->expectsOutput('Local project listing requires Qdrant collection enumeration.');
+    });
+
+    it('fails when odin sync is disabled', function (): void {
+        $this->odinMock->shouldReceive('isEnabled')->once()->andReturn(false);
+
+        $this->artisan('projects')
+            ->assertFailed()
+            ->expectsOutput('Odin sync is disabled. Set ODIN_SYNC_ENABLED=true to enable.');
+    });
+
+    it('warns when Odin is unreachable', function (): void {
+        $this->odinMock->shouldReceive('isEnabled')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('isAvailable')->once()->andReturn(false);
+
+        $this->artisan('projects')
+            ->assertSuccessful()
+            ->expectsOutput('Odin server is not reachable. Cannot list remote projects.');
+    });
+
+    it('shows empty projects message', function (): void {
+        $this->odinMock->shouldReceive('isEnabled')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('isAvailable')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('listProjects')->once()->andReturn([]);
+
+        $this->artisan('projects')
+            ->assertSuccessful()
+            ->expectsOutput('No projects found on Odin server.');
+    });
+
+    it('displays projects table', function (): void {
+        $this->odinMock->shouldReceive('isEnabled')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('isAvailable')->once()->andReturn(true);
+        $this->odinMock->shouldReceive('listProjects')->once()->andReturn([
+            ['name' => 'project-alpha', 'entry_count' => 42, 'last_synced' => '2025-06-01T12:00:00+00:00'],
+            ['name' => 'project-beta', 'entry_count' => 15, 'last_synced' => null],
+        ]);
+
+        $this->artisan('projects')
+            ->assertSuccessful();
+    });
+});

--- a/tests/Feature/KnowledgeStatsCommandTest.php
+++ b/tests/Feature/KnowledgeStatsCommandTest.php
@@ -3,12 +3,15 @@
 declare(strict_types=1);
 
 use App\Services\KnowledgeCacheService;
+use App\Services\OdinSyncService;
 use App\Services\QdrantService;
 
 describe('KnowledgeStatsCommand', function (): void {
     it('displays comprehensive analytics dashboard covering all code paths', function (): void {
         $qdrant = mock(QdrantService::class);
+        $odinSync = mock(OdinSyncService::class);
         app()->instance(QdrantService::class, $qdrant);
+        app()->instance(OdinSyncService::class, $odinSync);
 
         // Mixed entries testing all display logic in a single test due to static caching
         $entries = collect([
@@ -56,6 +59,10 @@ describe('KnowledgeStatsCommand', function (): void {
             ->once()
             ->andReturnNull();
 
+        $odinSync->shouldReceive('isEnabled')
+            ->once()
+            ->andReturn(false);
+
         $this->artisan('stats')
             ->assertSuccessful();
     });
@@ -63,7 +70,9 @@ describe('KnowledgeStatsCommand', function (): void {
     it('displays cache metrics when cache service is available', function (): void {
         $qdrant = mock(QdrantService::class);
         $cacheService = mock(KnowledgeCacheService::class);
+        $odinSync = mock(OdinSyncService::class);
         app()->instance(QdrantService::class, $qdrant);
+        app()->instance(OdinSyncService::class, $odinSync);
 
         $entries = collect([
             [
@@ -96,6 +105,58 @@ describe('KnowledgeStatsCommand', function (): void {
                 'embedding' => ['hits' => 10, 'misses' => 5],
                 'search' => ['hits' => 20, 'misses' => 3],
                 'stats' => ['hits' => 8, 'misses' => 2],
+            ]);
+
+        $odinSync->shouldReceive('isEnabled')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('stats')
+            ->assertSuccessful();
+    });
+
+    it('displays odin sync status when enabled', function (): void {
+        $qdrant = mock(QdrantService::class);
+        $odinSync = mock(OdinSyncService::class);
+        app()->instance(QdrantService::class, $qdrant);
+        app()->instance(OdinSyncService::class, $odinSync);
+
+        $entries = collect([
+            [
+                'id' => 1,
+                'title' => 'Test Entry',
+                'content' => 'Content',
+                'category' => 'testing',
+                'status' => 'validated',
+                'usage_count' => 5,
+                'tags' => [],
+            ],
+        ]);
+
+        $qdrant->shouldReceive('count')
+            ->once()
+            ->andReturn(1);
+
+        $qdrant->shouldReceive('scroll')
+            ->once()
+            ->with([], 1)
+            ->andReturn($entries);
+
+        $qdrant->shouldReceive('getCacheService')
+            ->once()
+            ->andReturnNull();
+
+        $odinSync->shouldReceive('isEnabled')
+            ->once()
+            ->andReturn(true);
+
+        $odinSync->shouldReceive('getStatus')
+            ->once()
+            ->andReturn([
+                'status' => 'synced',
+                'pending' => 2,
+                'last_synced' => '2025-06-01T12:00:00+00:00',
+                'last_error' => null,
             ]);
 
         $this->artisan('stats')

--- a/tests/Unit/Services/OdinSyncServiceTest.php
+++ b/tests/Unit/Services/OdinSyncServiceTest.php
@@ -1,0 +1,498 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\KnowledgePathService;
+use App\Services\OdinSyncService;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+
+beforeEach(function (): void {
+    $this->tempDir = sys_get_temp_dir().'/odin_sync_test_'.uniqid();
+    mkdir($this->tempDir, 0755, true);
+
+    $this->pathService = Mockery::mock(KnowledgePathService::class);
+    $this->pathService->shouldReceive('getKnowledgeDirectory')
+        ->andReturn($this->tempDir);
+
+    config(['services.odin.enabled' => true]);
+    config(['services.odin.url' => 'http://test-odin.local']);
+    config(['services.odin.token' => 'test-token']);
+    config(['services.odin.timeout' => 5]);
+    config(['services.odin.batch_size' => 50]);
+});
+
+afterEach(function (): void {
+    removeDirectory($this->tempDir);
+});
+
+describe('OdinSyncService configuration', function (): void {
+    it('reports enabled when config is true', function (): void {
+        $service = new OdinSyncService($this->pathService);
+
+        expect($service->isEnabled())->toBeTrue();
+    });
+
+    it('reports disabled when config is false', function (): void {
+        config(['services.odin.enabled' => false]);
+        $service = new OdinSyncService($this->pathService);
+
+        expect($service->isEnabled())->toBeFalse();
+    });
+});
+
+describe('OdinSyncService queue operations', function (): void {
+    it('queues an entry for sync', function (): void {
+        $service = new OdinSyncService($this->pathService);
+
+        $entry = [
+            'id' => 'test-1',
+            'title' => 'Test Entry',
+            'content' => 'Test content',
+        ];
+
+        $service->queueForSync($entry, 'upsert', 'myproject');
+
+        expect($service->getPendingCount())->toBe(1);
+    });
+
+    it('does not queue when disabled', function (): void {
+        config(['services.odin.enabled' => false]);
+        $service = new OdinSyncService($this->pathService);
+
+        $service->queueForSync(['id' => 'test-1', 'title' => 'Test', 'content' => 'Content']);
+
+        expect($service->getPendingCount())->toBe(0);
+    });
+
+    it('queues multiple entries', function (): void {
+        $service = new OdinSyncService($this->pathService);
+
+        $service->queueForSync(['id' => '1', 'title' => 'First', 'content' => 'Content 1']);
+        $service->queueForSync(['id' => '2', 'title' => 'Second', 'content' => 'Content 2']);
+        $service->queueForSync(['id' => '3', 'title' => 'Third', 'content' => 'Content 3'], 'delete');
+
+        expect($service->getPendingCount())->toBe(3);
+    });
+
+    it('clears the queue', function (): void {
+        $service = new OdinSyncService($this->pathService);
+
+        $service->queueForSync(['id' => '1', 'title' => 'Test', 'content' => 'Content']);
+        expect($service->getPendingCount())->toBe(1);
+
+        $service->clearQueue();
+        expect($service->getPendingCount())->toBe(0);
+    });
+
+    it('handles empty queue file gracefully', function (): void {
+        $service = new OdinSyncService($this->pathService);
+
+        expect($service->getPendingCount())->toBe(0);
+    });
+
+    it('handles corrupted queue file gracefully', function (): void {
+        file_put_contents($this->tempDir.'/sync_queue.json', 'not-valid-json');
+        $service = new OdinSyncService($this->pathService);
+
+        expect($service->getPendingCount())->toBe(0);
+    });
+});
+
+describe('OdinSyncService processQueue', function (): void {
+    it('processes empty queue', function (): void {
+        $service = new OdinSyncService($this->pathService);
+
+        $result = $service->processQueue();
+
+        expect($result)->toBe(['synced' => 0, 'failed' => 0, 'remaining' => 0]);
+    });
+
+    it('returns remaining when no token is set', function (): void {
+        config(['services.odin.token' => '']);
+        $service = new OdinSyncService($this->pathService);
+
+        $service->queueForSync(['id' => '1', 'title' => 'Test', 'content' => 'Content']);
+        $result = $service->processQueue();
+
+        expect($result['remaining'])->toBe(1);
+        expect($result['synced'])->toBe(0);
+    });
+
+    it('processes upsert queue items successfully', function (): void {
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode(['summary' => ['created' => 1, 'updated' => 0, 'failed' => 0]])),
+        ]);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+        app()->instance(Client::class, $mockClient);
+
+        $service = new OdinSyncService($this->pathService);
+
+        $service->queueForSync(['id' => '1', 'title' => 'Test Entry', 'content' => 'Content']);
+        $result = $service->processQueue();
+
+        expect($result['synced'])->toBe(1);
+        expect($result['failed'])->toBe(0);
+        expect($result['remaining'])->toBe(0);
+
+        app()->forgetInstance(Client::class);
+    });
+
+    it('handles push failure and retains items in queue', function (): void {
+        $mockHandler = new MockHandler([
+            new Response(500, [], 'Internal Server Error'),
+        ]);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+        app()->instance(Client::class, $mockClient);
+
+        $service = new OdinSyncService($this->pathService);
+
+        $service->queueForSync(['id' => '1', 'title' => 'Test Entry', 'content' => 'Content']);
+        $result = $service->processQueue();
+
+        expect($result['synced'])->toBe(0);
+        expect($result['failed'])->toBe(1);
+        expect($result['remaining'])->toBe(1);
+
+        app()->forgetInstance(Client::class);
+    });
+
+    it('processes delete queue items successfully', function (): void {
+        $mockHandler = new MockHandler([
+            new Response(204),
+        ]);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+        app()->instance(Client::class, $mockClient);
+
+        $service = new OdinSyncService($this->pathService);
+
+        $service->queueForSync(['id' => '1', 'title' => 'Test Entry', 'content' => 'Content'], 'delete');
+        $result = $service->processQueue();
+
+        expect($result['synced'])->toBe(1);
+        expect($result['failed'])->toBe(0);
+        expect($result['remaining'])->toBe(0);
+
+        app()->forgetInstance(Client::class);
+    });
+
+    it('handles delete failure', function (): void {
+        $mockHandler = new MockHandler([
+            new Response(500, [], 'Server Error'),
+        ]);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+        app()->instance(Client::class, $mockClient);
+
+        $service = new OdinSyncService($this->pathService);
+
+        $service->queueForSync(['id' => '1', 'title' => 'Test', 'content' => 'Content'], 'delete');
+        $result = $service->processQueue();
+
+        expect($result['synced'])->toBe(0);
+        expect($result['failed'])->toBe(1);
+        expect($result['remaining'])->toBe(1);
+
+        app()->forgetInstance(Client::class);
+    });
+});
+
+describe('OdinSyncService conflict resolution', function (): void {
+    it('picks local when local is newer', function (): void {
+        $service = new OdinSyncService($this->pathService);
+
+        $local = ['title' => 'Local', 'updated_at' => '2025-06-01T12:00:00+00:00'];
+        $remote = ['title' => 'Remote', 'updated_at' => '2025-05-01T12:00:00+00:00'];
+
+        $winner = $service->resolveConflict($local, $remote);
+
+        expect($winner)->toBe($local);
+    });
+
+    it('picks remote when remote is newer', function (): void {
+        $service = new OdinSyncService($this->pathService);
+
+        $local = ['title' => 'Local', 'updated_at' => '2025-05-01T12:00:00+00:00'];
+        $remote = ['title' => 'Remote', 'updated_at' => '2025-06-01T12:00:00+00:00'];
+
+        $winner = $service->resolveConflict($local, $remote);
+
+        expect($winner)->toBe($remote);
+    });
+
+    it('picks local when timestamps are equal', function (): void {
+        $service = new OdinSyncService($this->pathService);
+
+        $local = ['title' => 'Local', 'updated_at' => '2025-06-01T12:00:00+00:00'];
+        $remote = ['title' => 'Remote', 'updated_at' => '2025-06-01T12:00:00+00:00'];
+
+        $winner = $service->resolveConflict($local, $remote);
+
+        expect($winner)->toBe($local);
+    });
+
+    it('picks local when both timestamps are empty', function (): void {
+        $service = new OdinSyncService($this->pathService);
+
+        $local = ['title' => 'Local'];
+        $remote = ['title' => 'Remote'];
+
+        $winner = $service->resolveConflict($local, $remote);
+
+        expect($winner)->toBe($local);
+    });
+
+    it('picks remote when local timestamp is empty', function (): void {
+        $service = new OdinSyncService($this->pathService);
+
+        $local = ['title' => 'Local'];
+        $remote = ['title' => 'Remote', 'updated_at' => '2025-06-01T12:00:00+00:00'];
+
+        $winner = $service->resolveConflict($local, $remote);
+
+        expect($winner)->toBe($remote);
+    });
+
+    it('picks local when remote timestamp is empty', function (): void {
+        $service = new OdinSyncService($this->pathService);
+
+        $local = ['title' => 'Local', 'updated_at' => '2025-06-01T12:00:00+00:00'];
+        $remote = ['title' => 'Remote'];
+
+        $winner = $service->resolveConflict($local, $remote);
+
+        expect($winner)->toBe($local);
+    });
+});
+
+describe('OdinSyncService status', function (): void {
+    it('returns default status when no status file exists', function (): void {
+        $service = new OdinSyncService($this->pathService);
+
+        $status = $service->getStatus();
+
+        expect($status['status'])->toBe('idle');
+        expect($status['pending'])->toBe(0);
+        expect($status['last_synced'])->toBeNull();
+        expect($status['last_error'])->toBeNull();
+    });
+
+    it('returns pending status when queue has items', function (): void {
+        $service = new OdinSyncService($this->pathService);
+
+        $service->queueForSync(['id' => '1', 'title' => 'Test', 'content' => 'Content']);
+        $status = $service->getStatus();
+
+        expect($status['status'])->toBe('pending');
+        expect($status['pending'])->toBe(1);
+    });
+
+    it('handles corrupted status file gracefully', function (): void {
+        file_put_contents($this->tempDir.'/sync_status.json', 'not-valid-json');
+        $service = new OdinSyncService($this->pathService);
+
+        $status = $service->getStatus();
+
+        expect($status['status'])->toBe('idle');
+    });
+
+    it('updates status after successful sync', function (): void {
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode(['summary' => ['created' => 1]])),
+        ]);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+        app()->instance(Client::class, $mockClient);
+
+        $service = new OdinSyncService($this->pathService);
+        $service->queueForSync(['id' => '1', 'title' => 'Test', 'content' => 'Content']);
+        $service->processQueue();
+
+        $status = $service->getStatus();
+        expect($status['status'])->toBe('synced');
+        expect($status['last_synced'])->not->toBeNull();
+
+        app()->forgetInstance(Client::class);
+    });
+});
+
+describe('OdinSyncService connectivity', function (): void {
+    it('reports unavailable when URL is empty', function (): void {
+        config(['services.odin.url' => '']);
+        $service = new OdinSyncService($this->pathService);
+
+        expect($service->isAvailable())->toBeFalse();
+    });
+
+    it('reports unavailable when token is empty', function (): void {
+        config(['services.odin.token' => '']);
+        $service = new OdinSyncService($this->pathService);
+
+        expect($service->isAvailable())->toBeFalse();
+    });
+
+    it('reports available on successful health check', function (): void {
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode(['data' => []])),
+        ]);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+        app()->instance(Client::class, $mockClient);
+
+        $service = new OdinSyncService($this->pathService);
+
+        expect($service->isAvailable())->toBeTrue();
+
+        app()->forgetInstance(Client::class);
+    });
+
+    it('reports unavailable on failed health check', function (): void {
+        $mockHandler = new MockHandler([
+            new Response(500, [], 'Internal Server Error'),
+        ]);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+        app()->instance(Client::class, $mockClient);
+
+        $service = new OdinSyncService($this->pathService);
+
+        expect($service->isAvailable())->toBeFalse();
+
+        app()->forgetInstance(Client::class);
+    });
+});
+
+describe('OdinSyncService pull', function (): void {
+    it('returns empty when token is missing', function (): void {
+        config(['services.odin.token' => '']);
+        $service = new OdinSyncService($this->pathService);
+
+        expect($service->pullFromOdin())->toBe([]);
+    });
+
+    it('pulls entries from Odin', function (): void {
+        $entries = [
+            'data' => [
+                ['title' => 'Entry 1', 'content' => 'Content 1'],
+                ['title' => 'Entry 2', 'content' => 'Content 2'],
+            ],
+        ];
+
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode($entries)),
+        ]);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+        app()->instance(Client::class, $mockClient);
+
+        $service = new OdinSyncService($this->pathService);
+        $result = $service->pullFromOdin('myproject');
+
+        expect($result)->toHaveCount(2);
+        expect($result[0]['title'])->toBe('Entry 1');
+
+        app()->forgetInstance(Client::class);
+    });
+
+    it('returns empty on invalid response', function (): void {
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode(['invalid' => 'response'])),
+        ]);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+        app()->instance(Client::class, $mockClient);
+
+        $service = new OdinSyncService($this->pathService);
+        $result = $service->pullFromOdin();
+
+        expect($result)->toBe([]);
+
+        app()->forgetInstance(Client::class);
+    });
+
+    it('returns empty on HTTP error', function (): void {
+        $mockHandler = new MockHandler([
+            new Response(500, [], 'Error'),
+        ]);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+        app()->instance(Client::class, $mockClient);
+
+        $service = new OdinSyncService($this->pathService);
+        $result = $service->pullFromOdin();
+
+        expect($result)->toBe([]);
+
+        app()->forgetInstance(Client::class);
+    });
+});
+
+describe('OdinSyncService listProjects', function (): void {
+    it('returns empty when token is missing', function (): void {
+        config(['services.odin.token' => '']);
+        $service = new OdinSyncService($this->pathService);
+
+        expect($service->listProjects())->toBe([]);
+    });
+
+    it('returns projects list from Odin', function (): void {
+        $projects = [
+            'data' => [
+                ['name' => 'project-a', 'entry_count' => 10, 'last_synced' => '2025-06-01'],
+                ['name' => 'project-b', 'entry_count' => 5, 'last_synced' => null],
+            ],
+        ];
+
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode($projects)),
+        ]);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+        app()->instance(Client::class, $mockClient);
+
+        $service = new OdinSyncService($this->pathService);
+        $result = $service->listProjects();
+
+        expect($result)->toHaveCount(2);
+        expect($result[0]['name'])->toBe('project-a');
+
+        app()->forgetInstance(Client::class);
+    });
+
+    it('returns empty on server error', function (): void {
+        $mockHandler = new MockHandler([
+            new Response(500, [], 'Error'),
+        ]);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+        app()->instance(Client::class, $mockClient);
+
+        $service = new OdinSyncService($this->pathService);
+        $result = $service->listProjects();
+
+        expect($result)->toBe([]);
+
+        app()->forgetInstance(Client::class);
+    });
+
+    it('returns empty on invalid response', function (): void {
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode(['invalid' => 'data'])),
+        ]);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $mockClient = new Client(['handler' => $handlerStack]);
+        app()->instance(Client::class, $mockClient);
+
+        $service = new OdinSyncService($this->pathService);
+        $result = $service->listProjects();
+
+        expect($result)->toBe([]);
+
+        app()->forgetInstance(Client::class);
+    });
+});


### PR DESCRIPTION
## Summary

Closes #83

- **OdinSyncService**: File-based sync queue with offline-first design, last-write-wins conflict resolution, batch push/pull to Odin Qdrant server, project listing, and connectivity health checks
- **`know sync:odin`**: Manual sync command with `--push`, `--pull`, `--status`, `--clear`, and `--project` options. Defaults to two-way sync (push then pull). Gracefully handles offline state by retaining operations in queue
- **`know projects`**: Lists synced knowledge base projects from Odin server with entry counts and last sync timestamps
- **`know stats`**: Now shows Odin sync status (status, pending count, last synced) when sync is enabled
- **Configuration**: New `services.odin` config block with `ODIN_SYNC_ENABLED`, `ODIN_URL`, `ODIN_API_TOKEN`, `ODIN_TIMEOUT`, `ODIN_BATCH_SIZE` env vars
- **Full test coverage**: 50+ tests across OdinSyncService unit tests, OdinSyncCommand feature tests, ProjectsCommand feature tests, and updated KnowledgeStatsCommand tests

### Key Design Decisions

- **Offline-first**: All operations queue to `~/.knowledge/sync_queue.json` when Odin is unavailable, processed on next `sync:odin` run
- **Last-write-wins**: Conflict resolution compares `updated_at` timestamps; local wins on tie
- **File-based queue**: No additional infrastructure needed (no Redis queue dependency)
- **Batch processing**: Configurable batch size (default 50) for efficient API calls

## Test plan

- [x] PHPStan level 8 passes (0 errors)
- [x] Laravel Pint formatting passes
- [x] All 731 tests pass
- [x] OdinSyncService: queue operations, conflict resolution, connectivity, push/pull, projects listing
- [x] OdinSyncCommand: disabled state, status display, clear queue, push, pull with conflict resolution, two-way sync
- [x] ProjectsCommand: local flag, disabled state, unreachable server, empty projects, project table display
- [x] KnowledgeStatsCommand: sync status rendering when enabled/disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Odin synchronization for knowledge base management with push, pull, and status tracking capabilities.
  * Introduced command to sync knowledge with Odin, including queue management and conflict resolution.
  * Added command to browse synced projects with entry counts and sync timestamps.
  * Enhanced dashboard stats to display Odin sync status when enabled.

* **Tests**
  * Comprehensive test coverage added for all sync operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->