### PR TITLE
feat: add daily log staging before permanent storage

### DIFF
--- a/app/Commands/PromoteCommand.php
+++ b/app/Commands/PromoteCommand.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands;
+
+use App\Services\DailyLogService;
+use App\Services\QdrantService;
+use Illuminate\Support\Str;
+use LaravelZero\Framework\Commands\Command;
+
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\spin;
+use function Laravel\Prompts\table;
+use function Laravel\Prompts\warning;
+
+class PromoteCommand extends Command
+{
+    protected $signature = 'promote
+                            {--auto : Auto-promote entries matching categories with high confidence}
+                            {--date= : Promote entries from a specific date (YYYY-MM-DD)}
+                            {--id= : Promote a specific entry by ID}
+                            {--all : Promote all entries past retention period}
+                            {--retention= : Override retention period in days}
+                            {--dry-run : Show what would be promoted without actually promoting}';
+
+    protected $description = 'Promote staged daily log entries to permanent storage';
+
+    public function handle(DailyLogService $dailyLog, QdrantService $qdrant): int
+    {
+        /** @var bool $auto */
+        $auto = (bool) $this->option('auto');
+        /** @var string|null $date */
+        $date = is_string($this->option('date')) ? $this->option('date') : null;
+        /** @var string|null $entryId */
+        $entryId = is_string($this->option('id')) ? $this->option('id') : null;
+        /** @var bool $all */
+        $all = (bool) $this->option('all');
+        /** @var bool $dryRun */
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($entryId !== null) {
+            return $this->promoteById($dailyLog, $qdrant, $entryId, $dryRun);
+        }
+
+        if ($date !== null) {
+            return $this->promoteByDate($dailyLog, $qdrant, $date, $dryRun);
+        }
+
+        if ($auto) {
+            return $this->autoPromote($dailyLog, $qdrant, $dryRun);
+        }
+
+        $retentionOption = $this->option('retention');
+        $retentionDays = is_numeric($retentionOption) ? (int) $retentionOption : $dailyLog->getRetentionDays();
+
+        if ($all) {
+            return $this->promoteAll($dailyLog, $qdrant, $retentionDays, $dryRun);
+        }
+
+        // Default: show promotable entries
+        return $this->showPromotable($dailyLog, $retentionDays);
+    }
+
+    private function promoteById(DailyLogService $dailyLog, QdrantService $qdrant, string $entryId, bool $dryRun): int
+    {
+        foreach ($dailyLog->listDailyLogs() as $date) {
+            $entries = $dailyLog->readDailyLog($date);
+            foreach ($entries as $entry) {
+                if ($entry['id'] === $entryId) {
+                    if ($dryRun) {
+                        info("[dry-run] Would promote: {$entry['title']}");
+
+                        return self::SUCCESS;
+                    }
+
+                    return $this->promoteEntry($dailyLog, $qdrant, $entry, $date);
+                }
+            }
+        }
+
+        error("Entry not found: {$entryId}");
+
+        return self::FAILURE;
+    }
+
+    private function promoteByDate(DailyLogService $dailyLog, QdrantService $qdrant, string $date, bool $dryRun): int
+    {
+        $entries = $dailyLog->readDailyLog($date);
+
+        if ($entries === []) {
+            warning("No entries found for date: {$date}");
+
+            return self::SUCCESS;
+        }
+
+        $promoted = 0;
+        foreach ($entries as $entry) {
+            if ($dryRun) {
+                info("[dry-run] Would promote: {$entry['title']}");
+                $promoted++;
+
+                continue;
+            }
+
+            $result = $this->promoteEntry($dailyLog, $qdrant, $entry, $date);
+            if ($result === self::SUCCESS) {
+                $promoted++;
+            }
+        }
+
+        info("Promoted {$promoted} entries from {$date}");
+
+        return self::SUCCESS;
+    }
+
+    private function autoPromote(DailyLogService $dailyLog, QdrantService $qdrant, bool $dryRun): int
+    {
+        $entries = $dailyLog->getAutoPromotableEntries();
+
+        if ($entries === []) {
+            info('No entries eligible for auto-promotion');
+
+            return self::SUCCESS;
+        }
+
+        $promoted = 0;
+        foreach ($entries as $entry) {
+            if ($dryRun) {
+                info("[dry-run] Would auto-promote: {$entry['title']} (confidence: {$entry['confidence']}%, category: {$entry['category']})");
+                $promoted++;
+
+                continue;
+            }
+
+            $result = $this->promoteEntry($dailyLog, $qdrant, $entry, $entry['date']);
+            if ($result === self::SUCCESS) {
+                $promoted++;
+            }
+        }
+
+        info("Auto-promoted {$promoted} entries");
+
+        return self::SUCCESS;
+    }
+
+    private function promoteAll(DailyLogService $dailyLog, QdrantService $qdrant, int $retentionDays, bool $dryRun): int
+    {
+        $entries = $dailyLog->getPromotableEntries($retentionDays);
+
+        if ($entries === []) {
+            info('No entries past retention period');
+
+            return self::SUCCESS;
+        }
+
+        $promoted = 0;
+        foreach ($entries as $entry) {
+            if ($dryRun) {
+                info("[dry-run] Would promote: {$entry['title']} (from {$entry['date']})");
+                $promoted++;
+
+                continue;
+            }
+
+            $result = $this->promoteEntry($dailyLog, $qdrant, $entry, $entry['date']);
+            if ($result === self::SUCCESS) {
+                $promoted++;
+            }
+        }
+
+        info("Promoted {$promoted} entries past {$retentionDays}-day retention period");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array{id: string, title: string, content: string, section: string, category: ?string, tags: array<string>, priority: string, confidence: int}  $entry
+     */
+    private function promoteEntry(DailyLogService $dailyLog, QdrantService $qdrant, array $entry, string $date): int
+    {
+        $data = [
+            'id' => Str::uuid()->toString(),
+            'title' => $entry['title'],
+            'content' => $entry['content'],
+            'tags' => $entry['tags'],
+            'priority' => $entry['priority'],
+            'confidence' => $entry['confidence'],
+            'status' => 'validated',
+        ];
+
+        if ($entry['category'] !== null) {
+            $data['category'] = $entry['category'];
+        }
+
+        try {
+            $success = spin(
+                fn (): bool => $qdrant->upsert($data, 'default', false),
+                "Promoting: {$entry['title']}..."
+            );
+
+            if (! $success) {
+                error("Failed to promote: {$entry['title']}");
+
+                return self::FAILURE;
+            }
+        } catch (\Throwable $e) {
+            error("Failed to promote '{$entry['title']}': {$e->getMessage()}");
+
+            return self::FAILURE;
+        }
+
+        $dailyLog->removeEntry($date, $entry['id']);
+
+        return self::SUCCESS;
+    }
+
+    private function showPromotable(DailyLogService $dailyLog, int $retentionDays): int
+    {
+        $entries = $dailyLog->getPromotableEntries($retentionDays);
+        $autoEntries = $dailyLog->getAutoPromotableEntries();
+        $allLogs = $dailyLog->listDailyLogs();
+
+        if ($allLogs === []) {
+            info('No daily logs in staging');
+
+            return self::SUCCESS;
+        }
+
+        $totalEntries = 0;
+        foreach ($allLogs as $date) {
+            $totalEntries += count($dailyLog->readDailyLog($date));
+        }
+
+        table(
+            ['Metric', 'Value'],
+            [
+                ['Daily logs', (string) count($allLogs)],
+                ['Total staged entries', (string) $totalEntries],
+                ['Past retention period', (string) count($entries)],
+                ['Eligible for auto-promote', (string) count($autoEntries)],
+                ['Retention period', "{$retentionDays} days"],
+            ]
+        );
+
+        if ($entries !== []) {
+            info('Use --all to promote entries past retention period');
+        }
+
+        if ($autoEntries !== []) {
+            info('Use --auto to auto-promote high-confidence entries');
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Commands/StageCommand.php
+++ b/app/Commands/StageCommand.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands;
+
+use App\Services\DailyLogService;
+use App\Services\GitContextService;
+use LaravelZero\Framework\Commands\Command;
+
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\table;
+
+class StageCommand extends Command
+{
+    protected $signature = 'stage
+                            {title : The title of the knowledge entry}
+                            {--content= : The content of the knowledge entry}
+                            {--section=Notes : Section (Decisions, Corrections, Commitments, Notes)}
+                            {--category= : Category (debugging, architecture, testing, deployment, security)}
+                            {--tags= : Comma-separated tags}
+                            {--priority=medium : Priority level (critical, high, medium, low)}
+                            {--confidence=50 : Confidence level (0-100)}
+                            {--source= : Source URL or reference}
+                            {--ticket= : Related ticket number}
+                            {--author= : Author name}
+                            {--no-git : Skip automatic git context detection}';
+
+    protected $description = 'Stage a knowledge entry in the daily log for review before permanent storage';
+
+    private const VALID_SECTIONS = ['Decisions', 'Corrections', 'Commitments', 'Notes'];
+
+    private const VALID_CATEGORIES = ['debugging', 'architecture', 'testing', 'deployment', 'security'];
+
+    private const VALID_PRIORITIES = ['critical', 'high', 'medium', 'low'];
+
+    public function handle(DailyLogService $dailyLog, GitContextService $gitService): int
+    {
+        $titleArg = $this->argument('title');
+        /** @var string $title */
+        $title = is_string($titleArg) ? $titleArg : '';
+        /** @var string|null $content */
+        $content = is_string($this->option('content')) ? $this->option('content') : null;
+        /** @var string $section */
+        $section = is_string($this->option('section')) ? $this->option('section') : 'Notes';
+        /** @var string|null $category */
+        $category = is_string($this->option('category')) ? $this->option('category') : null;
+        /** @var string|null $tags */
+        $tags = is_string($this->option('tags')) ? $this->option('tags') : null;
+        /** @var string $priority */
+        $priority = is_string($this->option('priority')) ? $this->option('priority') : 'medium';
+        /** @var int|string $confidence */
+        $confidence = $this->option('confidence') ?? 50;
+        /** @var string|null $source */
+        $source = is_string($this->option('source')) ? $this->option('source') : null;
+        /** @var string|null $ticket */
+        $ticket = is_string($this->option('ticket')) ? $this->option('ticket') : null;
+        /** @var string|null $author */
+        $author = is_string($this->option('author')) ? $this->option('author') : null;
+        /** @var bool $noGit */
+        $noGit = (bool) $this->option('no-git');
+
+        if ($content === null || $content === '') {
+            error('The content field is required.');
+
+            return self::FAILURE;
+        }
+
+        if (! is_numeric($confidence) || $confidence < 0 || $confidence > 100) {
+            error('The confidence must be between 0 and 100.');
+
+            return self::FAILURE;
+        }
+
+        if (! in_array($section, self::VALID_SECTIONS, true)) {
+            error('Invalid section. Valid: '.implode(', ', self::VALID_SECTIONS));
+
+            return self::FAILURE;
+        }
+
+        if ($category !== null && ! in_array($category, self::VALID_CATEGORIES, true)) {
+            error('Invalid category. Valid: '.implode(', ', self::VALID_CATEGORIES));
+
+            return self::FAILURE;
+        }
+
+        if (! in_array($priority, self::VALID_PRIORITIES, true)) {
+            error('Invalid priority. Valid: '.implode(', ', self::VALID_PRIORITIES));
+
+            return self::FAILURE;
+        }
+
+        // Auto-detect author from git if not specified
+        if ($author === null && ! $noGit && $gitService->isGitRepository()) {
+            $gitContext = $gitService->getContext();
+            $author = $gitContext['author'] ?? null;
+        }
+
+        $entry = [
+            'title' => $title,
+            'content' => $content,
+            'section' => $section,
+            'category' => $category,
+            'priority' => $priority,
+            'confidence' => (int) $confidence,
+            'source' => $source,
+            'ticket' => $ticket,
+            'author' => $author,
+        ];
+
+        if (is_string($tags) && $tags !== '') {
+            $entry['tags'] = array_map('trim', explode(',', $tags));
+        }
+
+        $id = $dailyLog->stage($entry);
+
+        info('Entry staged in daily log!');
+
+        table(
+            ['Field', 'Value'],
+            [
+                ['ID', $id],
+                ['Title', $title],
+                ['Section', $section],
+                ['Category', $category ?? 'N/A'],
+                ['Priority', $priority],
+                ['Confidence', "{$confidence}%"],
+            ]
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Contracts\EmbeddingServiceInterface;
+use App\Services\DailyLogService;
 use App\Services\DeletionTracker;
 use App\Services\KnowledgeCacheService;
 use App\Services\KnowledgePathService;
@@ -134,6 +135,11 @@ class AppServiceProvider extends ServiceProvider
 
         // Odin sync service
         $this->app->singleton(OdinSyncService::class, fn ($app): \App\Services\OdinSyncService => new OdinSyncService(
+            $app->make(KnowledgePathService::class)
+        ));
+
+        // Daily log staging service
+        $this->app->singleton(DailyLogService::class, fn ($app): \App\Services\DailyLogService => new DailyLogService(
             $app->make(KnowledgePathService::class)
         ));
     }

--- a/app/Services/DailyLogService.php
+++ b/app/Services/DailyLogService.php
@@ -1,0 +1,423 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Carbon\Carbon;
+use Illuminate\Support\Str;
+
+class DailyLogService
+{
+    private const VALID_SECTIONS = ['Decisions', 'Corrections', 'Commitments', 'Notes'];
+
+    private const DEFAULT_RETENTION_DAYS = 7;
+
+    private const AUTO_PROMOTE_CONFIDENCE_THRESHOLD = 80;
+
+    private const VALID_CATEGORIES = ['debugging', 'architecture', 'testing', 'deployment', 'security'];
+
+    public function __construct(
+        private readonly KnowledgePathService $pathService,
+    ) {}
+
+    /**
+     * Get the staging directory path.
+     */
+    public function getStagingDirectory(): string
+    {
+        return $this->pathService->getKnowledgeDirectory().'/staging';
+    }
+
+    /**
+     * Get the path for a specific day's log file.
+     */
+    public function getDailyLogPath(string $date): string
+    {
+        return $this->getStagingDirectory().'/'.$date.'.md';
+    }
+
+    /**
+     * Stage an entry into today's daily log.
+     *
+     * @param  array{title: string, content: string, section?: string, category?: string|null, tags?: array<string>, priority?: string, confidence?: int, source?: string|null, ticket?: string|null, author?: string|null}  $entry
+     */
+    public function stage(array $entry): string
+    {
+        $date = Carbon::now()->format('Y-m-d');
+        $logPath = $this->getDailyLogPath($date);
+
+        $this->pathService->ensureDirectoryExists($this->getStagingDirectory());
+
+        $section = $entry['section'] ?? 'Notes';
+        if (! in_array($section, self::VALID_SECTIONS, true)) {
+            $section = 'Notes';
+        }
+
+        $id = Str::uuid()->toString();
+        $timestamp = Carbon::now()->format('H:i:s');
+
+        $entryBlock = $this->formatEntry($id, $timestamp, $entry);
+
+        if (! file_exists($logPath)) {
+            $content = $this->createDailyLog($date, $section, $entryBlock);
+        } else {
+            $content = (string) file_get_contents($logPath);
+            $content = $this->appendToSection($content, $section, $entryBlock);
+        }
+
+        file_put_contents($logPath, $content);
+
+        return $id;
+    }
+
+    /**
+     * Read all entries from a daily log file.
+     *
+     * @return array<int, array{id: string, timestamp: string, title: string, content: string, section: string, category: ?string, tags: array<string>, priority: string, confidence: int}>
+     */
+    public function readDailyLog(string $date): array
+    {
+        $logPath = $this->getDailyLogPath($date);
+
+        if (! file_exists($logPath)) {
+            return [];
+        }
+
+        $content = (string) file_get_contents($logPath);
+
+        return $this->parseEntries($content);
+    }
+
+    /**
+     * Get all daily log files in staging.
+     *
+     * @return array<string>
+     */
+    public function listDailyLogs(): array
+    {
+        $stagingDir = $this->getStagingDirectory();
+
+        if (! is_dir($stagingDir)) {
+            return [];
+        }
+
+        $files = scandir($stagingDir);
+        if ($files === false) {
+            return [];
+        }
+
+        $logs = [];
+        foreach ($files as $file) {
+            if (preg_match('/^\d{4}-\d{2}-\d{2}\.md$/', $file)) {
+                $logs[] = str_replace('.md', '', $file);
+            }
+        }
+
+        sort($logs);
+
+        return $logs;
+    }
+
+    /**
+     * Get entries that are ready for promotion (older than retention period).
+     *
+     * @return array<int, array{id: string, timestamp: string, title: string, content: string, section: string, category: ?string, tags: array<string>, priority: string, confidence: int, date: string}>
+     */
+    public function getPromotableEntries(int $retentionDays = self::DEFAULT_RETENTION_DAYS): array
+    {
+        $cutoffDate = Carbon::now()->subDays($retentionDays)->format('Y-m-d');
+        $promotable = [];
+
+        foreach ($this->listDailyLogs() as $date) {
+            if ($date <= $cutoffDate) {
+                $entries = $this->readDailyLog($date);
+                foreach ($entries as $entry) {
+                    $entry['date'] = $date;
+                    $promotable[] = $entry;
+                }
+            }
+        }
+
+        return $promotable;
+    }
+
+    /**
+     * Get entries eligible for auto-promotion (high confidence + matching category).
+     *
+     * @return array<int, array{id: string, timestamp: string, title: string, content: string, section: string, category: ?string, tags: array<string>, priority: string, confidence: int, date: string}>
+     */
+    public function getAutoPromotableEntries(): array
+    {
+        $all = [];
+
+        foreach ($this->listDailyLogs() as $date) {
+            $entries = $this->readDailyLog($date);
+            foreach ($entries as $entry) {
+                $entry['date'] = $date;
+                if ($this->isAutoPromotable($entry)) {
+                    $all[] = $entry;
+                }
+            }
+        }
+
+        return $all;
+    }
+
+    /**
+     * Remove a specific entry from its daily log file.
+     */
+    public function removeEntry(string $date, string $id): bool
+    {
+        $logPath = $this->getDailyLogPath($date);
+
+        if (! file_exists($logPath)) {
+            return false;
+        }
+
+        $content = (string) file_get_contents($logPath);
+        $pattern = '/<!-- entry:'.$this->escapeRegex($id).' -->.*?<!-- \/entry -->\n*/s';
+        $newContent = preg_replace($pattern, '', $content);
+
+        if ($newContent === null || $newContent === $content) {
+            return false;
+        }
+
+        // If the file is now essentially empty (just header), remove it
+        if ($this->isLogEmpty($newContent)) {
+            unlink($logPath);
+
+            return true;
+        }
+
+        file_put_contents($logPath, $newContent);
+
+        return true;
+    }
+
+    /**
+     * Remove an entire daily log file.
+     */
+    public function removeDailyLog(string $date): bool
+    {
+        $logPath = $this->getDailyLogPath($date);
+
+        if (! file_exists($logPath)) {
+            return false;
+        }
+
+        return unlink($logPath);
+    }
+
+    /**
+     * Get the configured retention days.
+     */
+    public function getRetentionDays(): int
+    {
+        $days = config('staging.retention_days');
+
+        return is_numeric($days) ? (int) $days : self::DEFAULT_RETENTION_DAYS;
+    }
+
+    /**
+     * Check if an entry qualifies for auto-promotion.
+     *
+     * @param  array{confidence: int, category: ?string}  $entry
+     */
+    private function isAutoPromotable(array $entry): bool
+    {
+        return $entry['confidence'] >= self::AUTO_PROMOTE_CONFIDENCE_THRESHOLD
+            && $entry['category'] !== null
+            && in_array($entry['category'], self::VALID_CATEGORIES, true);
+    }
+
+    /**
+     * Create a new daily log file with the first entry.
+     */
+    private function createDailyLog(string $date, string $section, string $entryBlock): string
+    {
+        $lines = ["# Daily Log: {$date}", ''];
+
+        foreach (self::VALID_SECTIONS as $validSection) {
+            $lines[] = "## {$validSection}";
+            $lines[] = '';
+            if ($validSection === $section) {
+                $lines[] = $entryBlock;
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Append an entry to the correct section of an existing log.
+     */
+    private function appendToSection(string $content, string $section, string $entryBlock): string
+    {
+        $sectionHeader = "## {$section}";
+
+        // Find the section and insert after it
+        $pos = strpos($content, $sectionHeader);
+        if ($pos === false) {
+            // Section doesn't exist, append it
+            return $content."\n{$sectionHeader}\n\n{$entryBlock}\n";
+        }
+
+        // Find the next section or end of file
+        $afterSection = $pos + strlen($sectionHeader);
+        $nextSectionPos = PHP_INT_MAX;
+
+        foreach (self::VALID_SECTIONS as $validSection) {
+            if ($validSection === $section) {
+                continue;
+            }
+            $nextPos = strpos($content, "## {$validSection}", $afterSection);
+            if ($nextPos !== false && $nextPos < $nextSectionPos) {
+                $nextSectionPos = $nextPos;
+            }
+        }
+
+        if ($nextSectionPos === PHP_INT_MAX) {
+            // This is the last section, append to end
+            return rtrim($content)."\n\n{$entryBlock}\n";
+        }
+
+        // Insert before the next section
+        $before = rtrim(substr($content, 0, $nextSectionPos));
+        $after = substr($content, $nextSectionPos);
+
+        return $before."\n\n{$entryBlock}\n\n".$after;
+    }
+
+    /**
+     * Format an entry as markdown.
+     *
+     * @param  array{title: string, content: string, category?: string|null, tags?: array<string>, priority?: string, confidence?: int, source?: string|null, ticket?: string|null, author?: string|null}  $entry
+     */
+    private function formatEntry(string $id, string $timestamp, array $entry): string
+    {
+        $lines = [];
+        $lines[] = "<!-- entry:{$id} -->";
+        $lines[] = "### [{$timestamp}] {$entry['title']}";
+        $lines[] = '';
+        $lines[] = $entry['content'];
+        $lines[] = '';
+
+        $meta = [];
+        if (isset($entry['category']) && $entry['category'] !== '') {
+            $meta[] = "**Category:** {$entry['category']}";
+        }
+        if (isset($entry['tags']) && is_array($entry['tags']) && $entry['tags'] !== []) {
+            $meta[] = '**Tags:** '.implode(', ', $entry['tags']);
+        }
+        $meta[] = '**Priority:** '.($entry['priority'] ?? 'medium');
+        $meta[] = '**Confidence:** '.($entry['confidence'] ?? 50).'%';
+
+        if (isset($entry['source']) && $entry['source'] !== '') {
+            $meta[] = "**Source:** {$entry['source']}";
+        }
+        if (isset($entry['ticket']) && $entry['ticket'] !== '') {
+            $meta[] = "**Ticket:** {$entry['ticket']}";
+        }
+        if (isset($entry['author']) && $entry['author'] !== '') {
+            $meta[] = "**Author:** {$entry['author']}";
+        }
+
+        $lines[] = implode(' | ', $meta);
+        $lines[] = '<!-- /entry -->';
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Parse all entries from a daily log markdown file.
+     *
+     * @return array<int, array{id: string, timestamp: string, title: string, content: string, section: string, category: ?string, tags: array<string>, priority: string, confidence: int}>
+     */
+    private function parseEntries(string $content): array
+    {
+        $entries = [];
+        $currentSection = 'Notes';
+
+        // Track which section each entry belongs to
+        $lines = explode("\n", $content);
+        $sectionMap = [];
+
+        foreach ($lines as $line) {
+            if (preg_match('/^## (.+)$/', $line, $matches)) {
+                $currentSection = trim($matches[1]);
+            }
+            if (preg_match('/<!-- entry:(.+?) -->/', $line, $matches)) {
+                $sectionMap[$matches[1]] = $currentSection;
+            }
+        }
+
+        // Parse entry blocks
+        preg_match_all('/<!-- entry:(.+?) -->\n### \[(\d{2}:\d{2}:\d{2})\] (.+?)\n\n(.*?)\n\n(.*?)\n<!-- \/entry -->/s', $content, $matches, PREG_SET_ORDER);
+
+        foreach ($matches as $match) {
+            $id = $match[1];
+            $metaLine = $match[5];
+
+            $entries[] = [
+                'id' => $id,
+                'timestamp' => $match[2],
+                'title' => $match[3],
+                'content' => $match[4],
+                'section' => $sectionMap[$id] ?? 'Notes',
+                'category' => $this->extractMeta($metaLine, 'Category'),
+                'tags' => $this->extractTags($metaLine),
+                'priority' => $this->extractMeta($metaLine, 'Priority') ?? 'medium',
+                'confidence' => (int) ($this->extractMeta($metaLine, 'Confidence') ?? '50'),
+            ];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * Extract a metadata value from the meta line.
+     */
+    private function extractMeta(string $metaLine, string $key): ?string
+    {
+        if (preg_match('/\*\*'.$key.':\*\*\s*([^|*]+)/', $metaLine, $match)) {
+            $value = trim($match[1]);
+            // Strip % from confidence values
+            $value = rtrim($value, '%');
+
+            return $value !== '' ? $value : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract tags from the meta line.
+     *
+     * @return array<string>
+     */
+    private function extractTags(string $metaLine): array
+    {
+        if (preg_match('/\*\*Tags:\*\*\s*([^|*]+)/', $metaLine, $match)) {
+            return array_map('trim', explode(',', trim($match[1])));
+        }
+
+        return [];
+    }
+
+    /**
+     * Check if a daily log has no entries left.
+     */
+    private function isLogEmpty(string $content): bool
+    {
+        return ! str_contains($content, '<!-- entry:');
+    }
+
+    /**
+     * Escape a string for use in regex.
+     */
+    private function escapeRegex(string $value): string
+    {
+        return preg_quote($value, '/');
+    }
+}

--- a/config/staging.php
+++ b/config/staging.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Staging Retention Period
+    |--------------------------------------------------------------------------
+    |
+    | Number of days entries sit in the daily log staging area before they
+    | become eligible for promotion to permanent storage.
+    |
+    */
+
+    'retention_days' => env('STAGING_RETENTION_DAYS', 7),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auto-Promote Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Entries matching an existing category with confidence >= threshold
+    | will be automatically promoted during 'know promote --auto'.
+    |
+    */
+
+    'auto_promote_confidence' => env('STAGING_AUTO_PROMOTE_CONFIDENCE', 80),
+];

--- a/tests/Feature/Commands/PromoteCommandTest.php
+++ b/tests/Feature/Commands/PromoteCommandTest.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\DailyLogService;
+use App\Services\QdrantService;
+
+beforeEach(function (): void {
+    $this->dailyLogService = mock(DailyLogService::class);
+    $this->qdrantService = mock(QdrantService::class);
+
+    app()->instance(DailyLogService::class, $this->dailyLogService);
+    app()->instance(QdrantService::class, $this->qdrantService);
+});
+
+it('shows promotable entries overview by default', function (): void {
+    $this->dailyLogService->shouldReceive('getRetentionDays')->andReturn(7);
+    $this->dailyLogService->shouldReceive('listDailyLogs')->andReturn(['2026-02-01', '2026-02-10']);
+    $this->dailyLogService->shouldReceive('getPromotableEntries')->with(7)->andReturn([
+        ['id' => 'abc', 'title' => 'Old', 'date' => '2026-02-01'],
+    ]);
+    $this->dailyLogService->shouldReceive('getAutoPromotableEntries')->andReturn([]);
+    $this->dailyLogService->shouldReceive('readDailyLog')
+        ->with('2026-02-01')
+        ->andReturn([['id' => 'abc']]);
+    $this->dailyLogService->shouldReceive('readDailyLog')
+        ->with('2026-02-10')
+        ->andReturn([['id' => 'def'], ['id' => 'ghi']]);
+
+    $this->artisan('promote')->assertSuccessful();
+});
+
+it('shows info when no daily logs exist', function (): void {
+    $this->dailyLogService->shouldReceive('getRetentionDays')->andReturn(7);
+    $this->dailyLogService->shouldReceive('listDailyLogs')->andReturn([]);
+    $this->dailyLogService->shouldReceive('getPromotableEntries')->with(7)->andReturn([]);
+    $this->dailyLogService->shouldReceive('getAutoPromotableEntries')->andReturn([]);
+
+    $this->artisan('promote')->assertSuccessful();
+});
+
+it('promotes a specific entry by ID', function (): void {
+    $entry = [
+        'id' => 'test-uuid-123',
+        'title' => 'Test Entry',
+        'content' => 'Test content.',
+        'section' => 'Decisions',
+        'category' => 'architecture',
+        'tags' => ['php'],
+        'priority' => 'high',
+        'confidence' => 90,
+    ];
+
+    $this->dailyLogService->shouldReceive('listDailyLogs')->andReturn(['2026-02-10']);
+    $this->dailyLogService->shouldReceive('readDailyLog')->with('2026-02-10')->andReturn([$entry]);
+    $this->qdrantService->shouldReceive('upsert')
+        ->once()
+        ->with(Mockery::on(fn ($data): bool => $data['title'] === 'Test Entry'
+            && $data['content'] === 'Test content.'
+            && $data['status'] === 'validated'), Mockery::any(), false)
+        ->andReturn(true);
+    $this->dailyLogService->shouldReceive('removeEntry')->with('2026-02-10', 'test-uuid-123')->andReturn(true);
+
+    $this->artisan('promote', ['--id' => 'test-uuid-123'])->assertSuccessful();
+});
+
+it('fails when promoting non-existent entry by ID', function (): void {
+    $this->dailyLogService->shouldReceive('listDailyLogs')->andReturn(['2026-02-10']);
+    $this->dailyLogService->shouldReceive('readDailyLog')->with('2026-02-10')->andReturn([]);
+
+    $this->artisan('promote', ['--id' => 'non-existent'])->assertFailed();
+});
+
+it('promotes all entries for a specific date', function (): void {
+    $entries = [
+        [
+            'id' => 'entry-1',
+            'title' => 'Entry 1',
+            'content' => 'Content 1.',
+            'section' => 'Decisions',
+            'category' => null,
+            'tags' => [],
+            'priority' => 'medium',
+            'confidence' => 50,
+        ],
+        [
+            'id' => 'entry-2',
+            'title' => 'Entry 2',
+            'content' => 'Content 2.',
+            'section' => 'Notes',
+            'category' => 'testing',
+            'tags' => ['test'],
+            'priority' => 'high',
+            'confidence' => 80,
+        ],
+    ];
+
+    $this->dailyLogService->shouldReceive('readDailyLog')->with('2026-02-10')->andReturn($entries);
+    $this->qdrantService->shouldReceive('upsert')->twice()->andReturn(true);
+    $this->dailyLogService->shouldReceive('removeEntry')->twice()->andReturn(true);
+
+    $this->artisan('promote', ['--date' => '2026-02-10'])->assertSuccessful();
+});
+
+it('handles empty date gracefully', function (): void {
+    $this->dailyLogService->shouldReceive('readDailyLog')->with('2026-01-01')->andReturn([]);
+
+    $this->artisan('promote', ['--date' => '2026-01-01'])->assertSuccessful();
+});
+
+it('auto-promotes eligible entries', function (): void {
+    $entries = [
+        [
+            'id' => 'auto-1',
+            'title' => 'Auto Entry',
+            'content' => 'Content.',
+            'section' => 'Decisions',
+            'category' => 'architecture',
+            'tags' => [],
+            'priority' => 'high',
+            'confidence' => 90,
+            'date' => '2026-02-10',
+        ],
+    ];
+
+    $this->dailyLogService->shouldReceive('getAutoPromotableEntries')->andReturn($entries);
+    $this->qdrantService->shouldReceive('upsert')->once()->andReturn(true);
+    $this->dailyLogService->shouldReceive('removeEntry')->with('2026-02-10', 'auto-1')->andReturn(true);
+
+    $this->artisan('promote', ['--auto' => true])->assertSuccessful();
+});
+
+it('handles no auto-promotable entries', function (): void {
+    $this->dailyLogService->shouldReceive('getAutoPromotableEntries')->andReturn([]);
+
+    $this->artisan('promote', ['--auto' => true])->assertSuccessful();
+});
+
+it('promotes all entries past retention period', function (): void {
+    $entries = [
+        [
+            'id' => 'old-1',
+            'title' => 'Old Entry',
+            'content' => 'Content.',
+            'section' => 'Notes',
+            'category' => null,
+            'tags' => [],
+            'priority' => 'medium',
+            'confidence' => 50,
+            'date' => '2026-01-01',
+        ],
+    ];
+
+    $this->dailyLogService->shouldReceive('getRetentionDays')->andReturn(7);
+    $this->dailyLogService->shouldReceive('getPromotableEntries')->with(7)->andReturn($entries);
+    $this->qdrantService->shouldReceive('upsert')->once()->andReturn(true);
+    $this->dailyLogService->shouldReceive('removeEntry')->with('2026-01-01', 'old-1')->andReturn(true);
+
+    $this->artisan('promote', ['--all' => true])->assertSuccessful();
+});
+
+it('handles no entries past retention period', function (): void {
+    $this->dailyLogService->shouldReceive('getRetentionDays')->andReturn(7);
+    $this->dailyLogService->shouldReceive('getPromotableEntries')->with(7)->andReturn([]);
+
+    $this->artisan('promote', ['--all' => true])->assertSuccessful();
+});
+
+it('supports custom retention period override', function (): void {
+    $this->dailyLogService->shouldReceive('getPromotableEntries')->with(14)->andReturn([]);
+
+    $this->artisan('promote', ['--all' => true, '--retention' => 14])->assertSuccessful();
+});
+
+it('supports dry-run mode for --id', function (): void {
+    $entry = [
+        'id' => 'dry-run-1',
+        'title' => 'Dry Run Entry',
+        'content' => 'Content.',
+        'section' => 'Notes',
+        'category' => null,
+        'tags' => [],
+        'priority' => 'medium',
+        'confidence' => 50,
+    ];
+
+    $this->dailyLogService->shouldReceive('listDailyLogs')->andReturn(['2026-02-10']);
+    $this->dailyLogService->shouldReceive('readDailyLog')->with('2026-02-10')->andReturn([$entry]);
+    $this->qdrantService->shouldNotReceive('upsert');
+    $this->dailyLogService->shouldNotReceive('removeEntry');
+
+    $this->artisan('promote', ['--id' => 'dry-run-1', '--dry-run' => true])->assertSuccessful();
+});
+
+it('supports dry-run mode for --date', function (): void {
+    $entries = [
+        [
+            'id' => 'e1',
+            'title' => 'Entry',
+            'content' => 'Content.',
+            'section' => 'Notes',
+            'category' => null,
+            'tags' => [],
+            'priority' => 'medium',
+            'confidence' => 50,
+        ],
+    ];
+
+    $this->dailyLogService->shouldReceive('readDailyLog')->with('2026-02-10')->andReturn($entries);
+    $this->qdrantService->shouldNotReceive('upsert');
+    $this->dailyLogService->shouldNotReceive('removeEntry');
+
+    $this->artisan('promote', ['--date' => '2026-02-10', '--dry-run' => true])->assertSuccessful();
+});
+
+it('supports dry-run mode for --auto', function (): void {
+    $entries = [
+        [
+            'id' => 'a1',
+            'title' => 'Auto',
+            'content' => 'Content.',
+            'section' => 'Notes',
+            'category' => 'testing',
+            'tags' => [],
+            'priority' => 'medium',
+            'confidence' => 85,
+            'date' => '2026-02-10',
+        ],
+    ];
+
+    $this->dailyLogService->shouldReceive('getAutoPromotableEntries')->andReturn($entries);
+    $this->qdrantService->shouldNotReceive('upsert');
+    $this->dailyLogService->shouldNotReceive('removeEntry');
+
+    $this->artisan('promote', ['--auto' => true, '--dry-run' => true])->assertSuccessful();
+});
+
+it('supports dry-run mode for --all', function (): void {
+    $entries = [
+        [
+            'id' => 'p1',
+            'title' => 'Promotable',
+            'content' => 'Content.',
+            'section' => 'Notes',
+            'category' => null,
+            'tags' => [],
+            'priority' => 'medium',
+            'confidence' => 50,
+            'date' => '2026-01-01',
+        ],
+    ];
+
+    $this->dailyLogService->shouldReceive('getRetentionDays')->andReturn(7);
+    $this->dailyLogService->shouldReceive('getPromotableEntries')->with(7)->andReturn($entries);
+    $this->qdrantService->shouldNotReceive('upsert');
+    $this->dailyLogService->shouldNotReceive('removeEntry');
+
+    $this->artisan('promote', ['--all' => true, '--dry-run' => true])->assertSuccessful();
+});
+
+it('handles upsert failure during promotion', function (): void {
+    $entry = [
+        'id' => 'fail-1',
+        'title' => 'Fail Entry',
+        'content' => 'Content.',
+        'section' => 'Notes',
+        'category' => null,
+        'tags' => [],
+        'priority' => 'medium',
+        'confidence' => 50,
+    ];
+
+    $this->dailyLogService->shouldReceive('listDailyLogs')->andReturn(['2026-02-10']);
+    $this->dailyLogService->shouldReceive('readDailyLog')->with('2026-02-10')->andReturn([$entry]);
+    $this->qdrantService->shouldReceive('upsert')->once()->andReturn(false);
+
+    $this->artisan('promote', ['--id' => 'fail-1'])->assertFailed();
+});
+
+it('handles upsert exception during promotion', function (): void {
+    $entry = [
+        'id' => 'exc-1',
+        'title' => 'Exception Entry',
+        'content' => 'Content.',
+        'section' => 'Notes',
+        'category' => null,
+        'tags' => [],
+        'priority' => 'medium',
+        'confidence' => 50,
+    ];
+
+    $this->dailyLogService->shouldReceive('listDailyLogs')->andReturn(['2026-02-10']);
+    $this->dailyLogService->shouldReceive('readDailyLog')->with('2026-02-10')->andReturn([$entry]);
+    $this->qdrantService->shouldReceive('upsert')->once()->andThrow(new RuntimeException('Connection failed'));
+
+    $this->artisan('promote', ['--id' => 'exc-1'])->assertFailed();
+});
+
+it('shows auto-promote hint when eligible entries exist', function (): void {
+    $this->dailyLogService->shouldReceive('getRetentionDays')->andReturn(7);
+    $this->dailyLogService->shouldReceive('listDailyLogs')->andReturn(['2026-02-10']);
+    $this->dailyLogService->shouldReceive('getPromotableEntries')->with(7)->andReturn([]);
+    $this->dailyLogService->shouldReceive('getAutoPromotableEntries')->andReturn([
+        ['id' => 'a1', 'title' => 'Auto', 'date' => '2026-02-10'],
+    ]);
+    $this->dailyLogService->shouldReceive('readDailyLog')
+        ->with('2026-02-10')
+        ->andReturn([['id' => 'a1']]);
+
+    $this->artisan('promote')->assertSuccessful();
+});

--- a/tests/Feature/Commands/StageCommandTest.php
+++ b/tests/Feature/Commands/StageCommandTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\DailyLogService;
+use App\Services\GitContextService;
+
+beforeEach(function (): void {
+    $this->dailyLogService = mock(DailyLogService::class);
+    $this->gitService = mock(GitContextService::class);
+
+    app()->instance(DailyLogService::class, $this->dailyLogService);
+    app()->instance(GitContextService::class, $this->gitService);
+});
+
+it('stages a knowledge entry with required fields', function (): void {
+    $this->gitService->shouldReceive('isGitRepository')->andReturn(false);
+
+    $this->dailyLogService->shouldReceive('stage')
+        ->once()
+        ->with(Mockery::on(fn ($data): bool => $data['title'] === 'Test Entry'
+            && $data['content'] === 'Test content'
+            && $data['section'] === 'Notes'))
+        ->andReturn('test-uuid');
+
+    $this->artisan('stage', [
+        'title' => 'Test Entry',
+        '--content' => 'Test content',
+    ])->assertSuccessful();
+});
+
+it('stages entry with all options', function (): void {
+    $this->gitService->shouldReceive('isGitRepository')->andReturn(false);
+
+    $this->dailyLogService->shouldReceive('stage')
+        ->once()
+        ->with(Mockery::on(fn ($data): bool => $data['title'] === 'Full Entry'
+            && $data['content'] === 'Full content'
+            && $data['section'] === 'Decisions'
+            && $data['category'] === 'architecture'
+            && $data['tags'] === ['php', 'laravel']
+            && $data['priority'] === 'high'
+            && $data['confidence'] === 90
+            && $data['source'] === 'https://example.com'
+            && $data['ticket'] === 'JIRA-123'
+            && $data['author'] === 'Test Author'))
+        ->andReturn('test-uuid');
+
+    $this->artisan('stage', [
+        'title' => 'Full Entry',
+        '--content' => 'Full content',
+        '--section' => 'Decisions',
+        '--category' => 'architecture',
+        '--tags' => 'php,laravel',
+        '--priority' => 'high',
+        '--confidence' => 90,
+        '--source' => 'https://example.com',
+        '--ticket' => 'JIRA-123',
+        '--author' => 'Test Author',
+    ])->assertSuccessful();
+});
+
+it('validates required content field', function (): void {
+    $this->dailyLogService->shouldNotReceive('stage');
+
+    $this->artisan('stage', [
+        'title' => 'No Content',
+    ])->assertFailed();
+});
+
+it('validates confidence range', function (): void {
+    $this->dailyLogService->shouldNotReceive('stage');
+
+    $this->artisan('stage', [
+        'title' => 'Invalid Confidence',
+        '--content' => 'Test',
+        '--confidence' => 150,
+    ])->assertFailed();
+});
+
+it('validates section is valid', function (): void {
+    $this->dailyLogService->shouldNotReceive('stage');
+
+    $this->artisan('stage', [
+        'title' => 'Invalid Section',
+        '--content' => 'Test',
+        '--section' => 'InvalidSection',
+    ])->assertFailed();
+});
+
+it('validates category is valid', function (): void {
+    $this->dailyLogService->shouldNotReceive('stage');
+
+    $this->artisan('stage', [
+        'title' => 'Invalid Category',
+        '--content' => 'Test',
+        '--category' => 'invalid-category',
+    ])->assertFailed();
+});
+
+it('validates priority is valid', function (): void {
+    $this->dailyLogService->shouldNotReceive('stage');
+
+    $this->artisan('stage', [
+        'title' => 'Invalid Priority',
+        '--content' => 'Test',
+        '--priority' => 'super-urgent',
+    ])->assertFailed();
+});
+
+it('auto-detects author from git context', function (): void {
+    $this->gitService->shouldReceive('isGitRepository')->andReturn(true);
+    $this->gitService->shouldReceive('getContext')->andReturn([
+        'repo' => 'test/repo',
+        'branch' => 'main',
+        'commit' => 'abc123',
+        'author' => 'Git Author',
+    ]);
+
+    $this->dailyLogService->shouldReceive('stage')
+        ->once()
+        ->with(Mockery::on(fn ($data): bool => $data['author'] === 'Git Author'))
+        ->andReturn('test-uuid');
+
+    $this->artisan('stage', [
+        'title' => 'Git Entry',
+        '--content' => 'Content',
+    ])->assertSuccessful();
+});
+
+it('skips git detection with --no-git flag', function (): void {
+    $this->gitService->shouldReceive('isGitRepository')->never();
+
+    $this->dailyLogService->shouldReceive('stage')
+        ->once()
+        ->with(Mockery::on(fn ($data): bool => $data['author'] === null))
+        ->andReturn('test-uuid');
+
+    $this->artisan('stage', [
+        'title' => 'No Git',
+        '--content' => 'Content',
+        '--no-git' => true,
+    ])->assertSuccessful();
+});
+
+it('stages entry in Corrections section', function (): void {
+    $this->gitService->shouldReceive('isGitRepository')->andReturn(false);
+
+    $this->dailyLogService->shouldReceive('stage')
+        ->once()
+        ->with(Mockery::on(fn ($data): bool => $data['section'] === 'Corrections'))
+        ->andReturn('test-uuid');
+
+    $this->artisan('stage', [
+        'title' => 'A Correction',
+        '--content' => 'Content',
+        '--section' => 'Corrections',
+    ])->assertSuccessful();
+});
+
+it('stages entry in Commitments section', function (): void {
+    $this->gitService->shouldReceive('isGitRepository')->andReturn(false);
+
+    $this->dailyLogService->shouldReceive('stage')
+        ->once()
+        ->with(Mockery::on(fn ($data): bool => $data['section'] === 'Commitments'))
+        ->andReturn('test-uuid');
+
+    $this->artisan('stage', [
+        'title' => 'A Commitment',
+        '--content' => 'Content',
+        '--section' => 'Commitments',
+    ])->assertSuccessful();
+});

--- a/tests/Unit/Services/DailyLogServiceTest.php
+++ b/tests/Unit/Services/DailyLogServiceTest.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\DailyLogService;
+use App\Services\KnowledgePathService;
+use Carbon\Carbon;
+
+beforeEach(function (): void {
+    $this->tempDir = sys_get_temp_dir().'/knowledge-test-'.uniqid();
+    mkdir($this->tempDir, 0755, true);
+
+    $this->pathService = mock(KnowledgePathService::class);
+    $this->pathService->shouldReceive('getKnowledgeDirectory')->andReturn($this->tempDir);
+    $this->pathService->shouldReceive('ensureDirectoryExists')->andReturnUsing(function (string $path): void {
+        if (! is_dir($path)) {
+            mkdir($path, 0755, true);
+        }
+    });
+
+    $this->service = new DailyLogService($this->pathService);
+
+    Carbon::setTestNow(Carbon::parse('2026-02-10 14:30:00'));
+});
+
+afterEach(function (): void {
+    Carbon::setTestNow();
+    removeDirectory($this->tempDir);
+});
+
+it('returns the staging directory path', function (): void {
+    expect($this->service->getStagingDirectory())
+        ->toBe($this->tempDir.'/staging');
+});
+
+it('returns the daily log path for a date', function (): void {
+    expect($this->service->getDailyLogPath('2026-02-10'))
+        ->toBe($this->tempDir.'/staging/2026-02-10.md');
+});
+
+it('stages an entry into today\'s daily log', function (): void {
+    $id = $this->service->stage([
+        'title' => 'Test Decision',
+        'content' => 'We decided to use Redis for caching.',
+        'section' => 'Decisions',
+        'category' => 'architecture',
+        'tags' => ['redis', 'caching'],
+        'priority' => 'high',
+        'confidence' => 90,
+    ]);
+
+    expect($id)->toBeString()->not->toBeEmpty();
+
+    $logPath = $this->service->getDailyLogPath('2026-02-10');
+    expect(file_exists($logPath))->toBeTrue();
+
+    $content = file_get_contents($logPath);
+    expect($content)
+        ->toContain('# Daily Log: 2026-02-10')
+        ->toContain('## Decisions')
+        ->toContain('## Corrections')
+        ->toContain('## Commitments')
+        ->toContain('## Notes')
+        ->toContain('Test Decision')
+        ->toContain('We decided to use Redis for caching.')
+        ->toContain('**Category:** architecture')
+        ->toContain('**Tags:** redis, caching')
+        ->toContain('**Priority:** high')
+        ->toContain('**Confidence:** 90%')
+        ->toContain("<!-- entry:{$id} -->")
+        ->toContain('<!-- /entry -->');
+});
+
+it('stages multiple entries into the same daily log', function (): void {
+    $id1 = $this->service->stage([
+        'title' => 'First Entry',
+        'content' => 'First content.',
+        'section' => 'Decisions',
+    ]);
+
+    $id2 = $this->service->stage([
+        'title' => 'Second Entry',
+        'content' => 'Second content.',
+        'section' => 'Notes',
+    ]);
+
+    $entries = $this->service->readDailyLog('2026-02-10');
+
+    expect($entries)->toHaveCount(2);
+    expect($entries[0]['id'])->toBe($id1);
+    expect($entries[1]['id'])->toBe($id2);
+});
+
+it('stages entries into correct sections', function (): void {
+    $this->service->stage([
+        'title' => 'A Decision',
+        'content' => 'Decision content.',
+        'section' => 'Decisions',
+    ]);
+
+    $this->service->stage([
+        'title' => 'A Correction',
+        'content' => 'Correction content.',
+        'section' => 'Corrections',
+    ]);
+
+    $entries = $this->service->readDailyLog('2026-02-10');
+
+    expect($entries[0]['section'])->toBe('Decisions');
+    expect($entries[1]['section'])->toBe('Corrections');
+});
+
+it('defaults to Notes section for invalid section', function (): void {
+    $this->service->stage([
+        'title' => 'Invalid Section',
+        'content' => 'Content.',
+        'section' => 'InvalidSection',
+    ]);
+
+    $entries = $this->service->readDailyLog('2026-02-10');
+    expect($entries[0]['section'])->toBe('Notes');
+});
+
+it('defaults to Notes section when section not provided', function (): void {
+    $this->service->stage([
+        'title' => 'No Section',
+        'content' => 'Content.',
+    ]);
+
+    $entries = $this->service->readDailyLog('2026-02-10');
+    expect($entries[0]['section'])->toBe('Notes');
+});
+
+it('reads entries from a daily log', function (): void {
+    $this->service->stage([
+        'title' => 'Test Entry',
+        'content' => 'Test content.',
+        'category' => 'testing',
+        'tags' => ['php', 'pest'],
+        'priority' => 'medium',
+        'confidence' => 75,
+    ]);
+
+    $entries = $this->service->readDailyLog('2026-02-10');
+
+    expect($entries)->toHaveCount(1);
+    expect($entries[0]['title'])->toBe('Test Entry');
+    expect($entries[0]['content'])->toBe('Test content.');
+    expect($entries[0]['category'])->toBe('testing');
+    expect($entries[0]['tags'])->toBe(['php', 'pest']);
+    expect($entries[0]['priority'])->toBe('medium');
+    expect($entries[0]['confidence'])->toBe(75);
+    expect($entries[0]['timestamp'])->toBe('14:30:00');
+});
+
+it('returns empty array for non-existent daily log', function (): void {
+    expect($this->service->readDailyLog('2026-01-01'))->toBe([]);
+});
+
+it('lists daily log files', function (): void {
+    $this->service->stage(['title' => 'Entry 1', 'content' => 'Content.']);
+
+    Carbon::setTestNow(Carbon::parse('2026-02-11 10:00:00'));
+    $this->service->stage(['title' => 'Entry 2', 'content' => 'Content.']);
+
+    $logs = $this->service->listDailyLogs();
+
+    expect($logs)->toBe(['2026-02-10', '2026-02-11']);
+});
+
+it('returns empty array when no staging directory exists', function (): void {
+    expect($this->service->listDailyLogs())->toBe([]);
+});
+
+it('gets promotable entries past retention period', function (): void {
+    // Create an old entry
+    Carbon::setTestNow(Carbon::parse('2026-01-01 10:00:00'));
+    $this->service->stage(['title' => 'Old Entry', 'content' => 'Old.']);
+
+    // Create a recent entry
+    Carbon::setTestNow(Carbon::parse('2026-02-10 10:00:00'));
+    $this->service->stage(['title' => 'New Entry', 'content' => 'New.']);
+
+    $promotable = $this->service->getPromotableEntries(7);
+
+    expect($promotable)->toHaveCount(1);
+    expect($promotable[0]['title'])->toBe('Old Entry');
+    expect($promotable[0]['date'])->toBe('2026-01-01');
+});
+
+it('gets auto-promotable entries with high confidence and valid category', function (): void {
+    $this->service->stage([
+        'title' => 'High Confidence',
+        'content' => 'Content.',
+        'category' => 'architecture',
+        'confidence' => 90,
+    ]);
+
+    $this->service->stage([
+        'title' => 'Low Confidence',
+        'content' => 'Content.',
+        'category' => 'testing',
+        'confidence' => 30,
+    ]);
+
+    $this->service->stage([
+        'title' => 'No Category High Conf',
+        'content' => 'Content.',
+        'confidence' => 95,
+    ]);
+
+    $autoPromotable = $this->service->getAutoPromotableEntries();
+
+    expect($autoPromotable)->toHaveCount(1);
+    expect($autoPromotable[0]['title'])->toBe('High Confidence');
+});
+
+it('removes a specific entry from a daily log', function (): void {
+    $id1 = $this->service->stage(['title' => 'Keep', 'content' => 'Keep.']);
+    $id2 = $this->service->stage(['title' => 'Remove', 'content' => 'Remove.']);
+
+    $result = $this->service->removeEntry('2026-02-10', $id2);
+
+    expect($result)->toBeTrue();
+
+    $entries = $this->service->readDailyLog('2026-02-10');
+    expect($entries)->toHaveCount(1);
+    expect($entries[0]['id'])->toBe($id1);
+});
+
+it('removes the daily log file when last entry is removed', function (): void {
+    $id = $this->service->stage(['title' => 'Only Entry', 'content' => 'Content.']);
+
+    $result = $this->service->removeEntry('2026-02-10', $id);
+
+    expect($result)->toBeTrue();
+    expect(file_exists($this->service->getDailyLogPath('2026-02-10')))->toBeFalse();
+});
+
+it('returns false when removing entry from non-existent log', function (): void {
+    expect($this->service->removeEntry('2026-01-01', 'non-existent'))->toBeFalse();
+});
+
+it('returns false when removing non-existent entry', function (): void {
+    $this->service->stage(['title' => 'Entry', 'content' => 'Content.']);
+
+    expect($this->service->removeEntry('2026-02-10', 'non-existent-id'))->toBeFalse();
+});
+
+it('removes an entire daily log file', function (): void {
+    $this->service->stage(['title' => 'Entry', 'content' => 'Content.']);
+
+    $result = $this->service->removeDailyLog('2026-02-10');
+
+    expect($result)->toBeTrue();
+    expect(file_exists($this->service->getDailyLogPath('2026-02-10')))->toBeFalse();
+});
+
+it('returns false when removing non-existent daily log', function (): void {
+    expect($this->service->removeDailyLog('2026-01-01'))->toBeFalse();
+});
+
+it('returns configured retention days', function (): void {
+    config(['staging.retention_days' => 14]);
+
+    expect($this->service->getRetentionDays())->toBe(14);
+});
+
+it('returns default retention days when not configured', function (): void {
+    config(['staging.retention_days' => null]);
+
+    expect($this->service->getRetentionDays())->toBe(7);
+});
+
+it('stages entry with source and ticket metadata', function (): void {
+    $this->service->stage([
+        'title' => 'With Metadata',
+        'content' => 'Content.',
+        'source' => 'https://example.com',
+        'ticket' => 'JIRA-123',
+        'author' => 'Test Author',
+    ]);
+
+    $logPath = $this->service->getDailyLogPath('2026-02-10');
+    $content = file_get_contents($logPath);
+
+    expect($content)
+        ->toContain('**Source:** https://example.com')
+        ->toContain('**Ticket:** JIRA-123')
+        ->toContain('**Author:** Test Author');
+});
+
+it('stages entry with default priority and confidence', function (): void {
+    $this->service->stage([
+        'title' => 'Defaults',
+        'content' => 'Content.',
+    ]);
+
+    $entries = $this->service->readDailyLog('2026-02-10');
+
+    expect($entries[0]['priority'])->toBe('medium');
+    expect($entries[0]['confidence'])->toBe(50);
+});
+
+it('handles entries in Commitments section', function (): void {
+    $this->service->stage([
+        'title' => 'Commitment',
+        'content' => 'We commit to this.',
+        'section' => 'Commitments',
+    ]);
+
+    $entries = $this->service->readDailyLog('2026-02-10');
+    expect($entries[0]['section'])->toBe('Commitments');
+});
+
+it('returns empty for scandir failure on non-dir staging', function (): void {
+    // staging dir doesn't exist
+    expect($this->service->listDailyLogs())->toBe([]);
+});
+
+it('ignores non-date files in staging directory', function (): void {
+    $stagingDir = $this->tempDir.'/staging';
+    mkdir($stagingDir, 0755, true);
+
+    // Create a non-date file
+    file_put_contents($stagingDir.'/notes.txt', 'not a daily log');
+
+    // Create a valid date file
+    $this->service->stage(['title' => 'Entry', 'content' => 'Content.']);
+
+    $logs = $this->service->listDailyLogs();
+
+    expect($logs)->toBe(['2026-02-10']);
+});


### PR DESCRIPTION
## Summary
- Adds a staging layer where new knowledge captures land in timestamped daily log files (e.g. `2026-02-10.md`) in `~/.knowledge/staging/` before promotion to permanent Qdrant storage
- New `know stage` command stages entries with section support (Decisions, Corrections, Commitments, Notes) and metadata
- New `know promote` command moves validated entries to permanent storage with `--auto`, `--all`, `--date`, `--id`, and `--dry-run` options
- Entries sit in staging for a configurable retention period (default 7 days)
- Auto-promotion for entries matching existing categories with high confidence (>=80%)

## New Files
| File | Purpose |
|------|---------|
| `app/Services/DailyLogService.php` | Core staging service - manages daily log files, entry parsing, promotion eligibility |
| `app/Commands/StageCommand.php` | `know stage` - stages entries into daily log |
| `app/Commands/PromoteCommand.php` | `know promote` - promotes staged entries to permanent storage |
| `config/staging.php` | Staging configuration (retention_days, auto_promote_confidence) |
| `tests/Unit/Services/DailyLogServiceTest.php` | 26 unit tests for DailyLogService |
| `tests/Feature/Commands/PromoteCommandTest.php` | 18 feature tests for PromoteCommand |
| `tests/Feature/Commands/StageCommandTest.php` | 11 feature tests for StageCommand |

## Test plan
- [x] All 55 new tests pass (26 unit + 18 promote + 11 stage)
- [x] Full test suite passes (733 passed, 5 pre-existing skips)
- [x] PHPStan level 8 passes with 0 errors
- [x] Laravel Pint formatting passes

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI command to stage knowledge entries with metadata (section, category, tags, priority, confidence) and view a summary.
  * CLI command to promote staged entries to permanent storage by ID, date, auto-promote, or bulk, with dry-run support and progress/status messages.
* **Chores**
  * New staging configuration for retention and auto-promotion thresholds.
* **Tests**
  * Extensive unit and feature tests covering staging, promotion flows, validation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->