### PR TITLE
feat: add Write Gate to filter knowledge before persistence

### DIFF
--- a/app/Services/WriteGateService.php
+++ b/app/Services/WriteGateService.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+class WriteGateService
+{
+    /** @var array<string, bool> */
+    private array $enabledCriteria;
+
+    /**
+     * @param  array<string, bool>|null  $criteria  Override criteria (null = use config defaults)
+     */
+    public function __construct(?array $criteria = null)
+    {
+        $this->enabledCriteria = $criteria ?? $this->loadCriteria();
+    }
+
+    /**
+     * Evaluate a knowledge entry against the write gate criteria.
+     *
+     * @param  array<string, mixed>  $entry
+     * @return array{passed: bool, matched: array<string>, reason: string}
+     */
+    public function evaluate(array $entry): array
+    {
+        $matched = [];
+
+        foreach ($this->enabledCriteria as $criterion => $enabled) {
+            if (! $enabled) {
+                continue;
+            }
+
+            if ($this->matchesCriterion($criterion, $entry)) {
+                $matched[] = $criterion;
+            }
+        }
+
+        if ($matched === []) {
+            return [
+                'passed' => false,
+                'matched' => [],
+                'reason' => 'Entry does not meet any write gate criteria. Knowledge must demonstrate at least one of: '
+                    .$this->formatEnabledCriteria()
+                    .'. Use --force to bypass.',
+            ];
+        }
+
+        return [
+            'passed' => true,
+            'matched' => $matched,
+            'reason' => '',
+        ];
+    }
+
+    /**
+     * Get the currently enabled criteria.
+     *
+     * @return array<string, bool>
+     */
+    public function getEnabledCriteria(): array
+    {
+        return $this->enabledCriteria;
+    }
+
+    /**
+     * Check if an entry matches a specific criterion.
+     *
+     * @param  array<string, mixed>  $entry
+     */
+    private function matchesCriterion(string $criterion, array $entry): bool
+    {
+        return match ($criterion) {
+            'behavioral_impact' => $this->hasBehavioralImpact($entry),
+            'commitment_weight' => $this->hasCommitmentWeight($entry),
+            'decision_rationale' => $this->hasDecisionRationale($entry),
+            'durable_facts' => $this->hasDurableFacts($entry),
+            'explicit_instruction' => $this->hasExplicitInstruction($entry),
+            default => false,
+        };
+    }
+
+    /**
+     * Behavioral Impact: Entry describes something that changes how the system or team operates.
+     * Signals: high/critical priority, deployment/security/architecture categories.
+     *
+     * @param  array<string, mixed>  $entry
+     */
+    private function hasBehavioralImpact(array $entry): bool
+    {
+        $priority = $entry['priority'] ?? 'medium';
+        if (in_array($priority, ['critical', 'high'], true)) {
+            return true;
+        }
+
+        $category = $entry['category'] ?? null;
+        if (in_array($category, ['deployment', 'security', 'architecture'], true)) {
+            return true;
+        }
+
+        $text = strtolower($entry['title'].' '.$entry['content']);
+        $signals = ['must ', 'always ', 'never ', 'required', 'breaking change', 'migration'];
+
+        foreach ($signals as $signal) {
+            if (str_contains($text, $signal)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Commitment Weight: Entry represents a decision that constrains future choices.
+     * Signals: architecture category, high confidence, validated status.
+     *
+     * @param  array<string, mixed>  $entry
+     */
+    private function hasCommitmentWeight(array $entry): bool
+    {
+        $category = $entry['category'] ?? null;
+        $confidence = $entry['confidence'] ?? 0;
+
+        if ($category === 'architecture' && $confidence >= 80) {
+            return true;
+        }
+
+        $status = $entry['status'] ?? 'draft';
+        if ($status === 'validated') {
+            return true;
+        }
+
+        $text = strtolower($entry['title'].' '.$entry['content']);
+        $signals = ['we chose', 'we decided', 'adopted', 'standard', 'convention', 'commitment'];
+
+        foreach ($signals as $signal) {
+            if (str_contains($text, $signal)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Decision Rationale: Entry explains *why* something was decided.
+     * Signals: content with reasoning patterns, architecture/debugging categories.
+     *
+     * @param  array<string, mixed>  $entry
+     */
+    private function hasDecisionRationale(array $entry): bool
+    {
+        $text = strtolower($entry['title'].' '.$entry['content']);
+        $signals = [
+            'because', 'reason', 'rationale', 'trade-off', 'tradeoff',
+            'alternative', 'pros and cons', 'decided against', 'opted for',
+            'why we', 'the decision',
+        ];
+
+        foreach ($signals as $signal) {
+            if (str_contains($text, $signal)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Durable Facts: Entry captures stable, long-lived knowledge.
+     * Signals: high confidence, validated status, specific categories.
+     *
+     * @param  array<string, mixed>  $entry
+     */
+    private function hasDurableFacts(array $entry): bool
+    {
+        $confidence = $entry['confidence'] ?? 0;
+        if ($confidence >= 80) {
+            return true;
+        }
+
+        $status = $entry['status'] ?? 'draft';
+        $category = $entry['category'] ?? null;
+        if ($status === 'validated' && $category !== null) {
+            return true;
+        }
+
+        $text = strtolower($entry['title'].' '.$entry['content']);
+        $signals = [
+            'specification', 'api contract', 'schema', 'protocol',
+            'invariant', 'constraint', 'requirement', 'documentation',
+        ];
+
+        foreach ($signals as $signal) {
+            if (str_contains($text, $signal)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Explicit Instruction: Entry contains a direct instruction or rule.
+     * Signals: imperative language, rule patterns, tags indicating instructions.
+     *
+     * @param  array<string, mixed>  $entry
+     */
+    private function hasExplicitInstruction(array $entry): bool
+    {
+        $tags = $entry['tags'] ?? [];
+        $instructionTags = ['rule', 'instruction', 'policy', 'guideline', 'standard', 'process'];
+
+        foreach ($tags as $tag) {
+            if (in_array(strtolower($tag), $instructionTags, true)) {
+                return true;
+            }
+        }
+
+        $text = strtolower($entry['title'].' '.$entry['content']);
+        $signals = [
+            'you must', 'do not', 'don\'t', 'ensure that', 'make sure',
+            'rule:', 'policy:', 'always use', 'never use', 'step 1',
+        ];
+
+        foreach ($signals as $signal) {
+            if (str_contains($text, $signal)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function loadCriteria(): array
+    {
+        /** @var array<string, bool> $configured */
+        $configured = config('write-gate.criteria', []);
+
+        if ($configured !== []) {
+            return $configured;
+        }
+
+        return self::defaultCriteria();
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    public static function defaultCriteria(): array
+    {
+        return [
+            'behavioral_impact' => true,
+            'commitment_weight' => true,
+            'decision_rationale' => true,
+            'durable_facts' => true,
+            'explicit_instruction' => true,
+        ];
+    }
+
+    private function formatEnabledCriteria(): string
+    {
+        $labels = [
+            'behavioral_impact' => 'Behavioral Impact',
+            'commitment_weight' => 'Commitment Weight',
+            'decision_rationale' => 'Decision Rationale',
+            'durable_facts' => 'Durable Facts',
+            'explicit_instruction' => 'Explicit Instruction',
+        ];
+
+        $enabled = array_filter($this->enabledCriteria);
+
+        return implode(', ', array_map(
+            fn (string $key): string => $labels[$key] ?? $key,
+            array_keys($enabled)
+        ));
+    }
+}

--- a/config/write-gate.php
+++ b/config/write-gate.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Write Gate Criteria
+    |--------------------------------------------------------------------------
+    |
+    | Each criterion can be enabled or disabled. An entry must match at least
+    | one enabled criterion to pass the write gate. Use --force to bypass.
+    |
+    | These defaults can be overridden per-project via ~/.knowledge/config.json:
+    |   { "write_gate": { "criteria": { "behavioral_impact": false } } }
+    |
+    */
+    'criteria' => [
+        'behavioral_impact' => (bool) env('WRITE_GATE_BEHAVIORAL_IMPACT', true),
+        'commitment_weight' => (bool) env('WRITE_GATE_COMMITMENT_WEIGHT', true),
+        'decision_rationale' => (bool) env('WRITE_GATE_DECISION_RATIONALE', true),
+        'durable_facts' => (bool) env('WRITE_GATE_DURABLE_FACTS', true),
+        'explicit_instruction' => (bool) env('WRITE_GATE_EXPLICIT_INSTRUCTION', true),
+    ],
+];

--- a/tests/Feature/Commands/KnowledgeAddCommandTest.php
+++ b/tests/Feature/Commands/KnowledgeAddCommandTest.php
@@ -5,10 +5,17 @@ declare(strict_types=1);
 use App\Exceptions\Qdrant\DuplicateEntryException;
 use App\Services\GitContextService;
 use App\Services\QdrantService;
+use App\Services\WriteGateService;
 
 beforeEach(function (): void {
     $this->mockQdrant = Mockery::mock(QdrantService::class);
     $this->app->instance(QdrantService::class, $this->mockQdrant);
+
+    $this->mockWriteGate = Mockery::mock(WriteGateService::class);
+    $this->mockWriteGate->shouldReceive('evaluate')
+        ->andReturn(['passed' => true, 'matched' => ['durable_facts'], 'reason' => ''])
+        ->byDefault();
+    $this->app->instance(WriteGateService::class, $this->mockWriteGate);
 });
 
 afterEach(function (): void {

--- a/tests/Unit/WriteGateServiceTest.php
+++ b/tests/Unit/WriteGateServiceTest.php
@@ -1,0 +1,375 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\WriteGateService;
+
+describe('WriteGateService', function (): void {
+    describe('behavioral_impact criterion', function (): void {
+        it('passes entries with critical priority', function (): void {
+            $gate = new WriteGateService;
+            $result = $gate->evaluate([
+                'title' => 'Generic title',
+                'content' => 'Generic content',
+                'priority' => 'critical',
+            ]);
+
+            expect($result['passed'])->toBeTrue();
+            expect($result['matched'])->toContain('behavioral_impact');
+        });
+
+        it('passes entries with high priority', function (): void {
+            $gate = new WriteGateService;
+            $result = $gate->evaluate([
+                'title' => 'Generic title',
+                'content' => 'Generic content',
+                'priority' => 'high',
+            ]);
+
+            expect($result['passed'])->toBeTrue();
+            expect($result['matched'])->toContain('behavioral_impact');
+        });
+
+        it('passes entries with security category', function (): void {
+            $gate = new WriteGateService;
+            $result = $gate->evaluate([
+                'title' => 'Generic title',
+                'content' => 'Generic content',
+                'category' => 'security',
+            ]);
+
+            expect($result['passed'])->toBeTrue();
+            expect($result['matched'])->toContain('behavioral_impact');
+        });
+
+        it('passes entries with deployment category', function (): void {
+            $gate = new WriteGateService;
+            $result = $gate->evaluate([
+                'title' => 'Generic title',
+                'content' => 'Generic content',
+                'category' => 'deployment',
+            ]);
+
+            expect($result['passed'])->toBeTrue();
+            expect($result['matched'])->toContain('behavioral_impact');
+        });
+
+        it('passes entries with architecture category', function (): void {
+            $gate = new WriteGateService;
+            $result = $gate->evaluate([
+                'title' => 'Generic title',
+                'content' => 'Generic content',
+                'category' => 'architecture',
+            ]);
+
+            expect($result['passed'])->toBeTrue();
+        });
+
+        it('passes entries with behavioral signal words', function (): void {
+            $gate = new WriteGateService;
+            $signals = ['must use this', 'always run tests', 'never deploy on friday', 'required for all', 'breaking change detected', 'migration needed'];
+
+            foreach ($signals as $signal) {
+                $result = $gate->evaluate([
+                    'title' => 'Entry',
+                    'content' => "This is {$signal} in production",
+                ]);
+
+                expect($result['passed'])->toBeTrue("Failed for signal: {$signal}");
+            }
+        });
+    });
+
+    describe('commitment_weight criterion', function (): void {
+        it('passes architecture entries with high confidence', function (): void {
+            $gate = new WriteGateService;
+            $result = $gate->evaluate([
+                'title' => 'Generic title',
+                'content' => 'Generic content',
+                'category' => 'architecture',
+                'confidence' => 80,
+            ]);
+
+            expect($result['passed'])->toBeTrue();
+            expect($result['matched'])->toContain('commitment_weight');
+        });
+
+        it('passes validated entries', function (): void {
+            $gate = new WriteGateService;
+            $result = $gate->evaluate([
+                'title' => 'Generic title',
+                'content' => 'Generic content',
+                'status' => 'validated',
+            ]);
+
+            expect($result['passed'])->toBeTrue();
+            expect($result['matched'])->toContain('commitment_weight');
+        });
+
+        it('passes entries with commitment language', function (): void {
+            $gate = new WriteGateService;
+            $result = $gate->evaluate([
+                'title' => 'Generic title',
+                'content' => 'We decided to use PostgreSQL for all new services',
+            ]);
+
+            expect($result['passed'])->toBeTrue();
+            expect($result['matched'])->toContain('commitment_weight');
+        });
+    });
+
+    describe('decision_rationale criterion', function (): void {
+        it('passes entries explaining why decisions were made', function (): void {
+            $gate = new WriteGateService;
+            $signals = [
+                'because the latency was too high',
+                'the reason for this choice',
+                'rationale behind the architecture',
+                'we considered the trade-off',
+                'alternative approaches were evaluated',
+                'pros and cons of each approach',
+                'decided against using microservices',
+                'opted for a monolith',
+                'why we chose Laravel',
+            ];
+
+            foreach ($signals as $signal) {
+                $result = $gate->evaluate([
+                    'title' => 'Entry',
+                    'content' => $signal,
+                ]);
+
+                expect($result['passed'])->toBeTrue("Failed for signal: {$signal}");
+                expect($result['matched'])->toContain('decision_rationale');
+            }
+        });
+    });
+
+    describe('durable_facts criterion', function (): void {
+        it('passes entries with high confidence', function (): void {
+            $gate = new WriteGateService;
+            $result = $gate->evaluate([
+                'title' => 'Generic title',
+                'content' => 'Generic content',
+                'confidence' => 85,
+            ]);
+
+            expect($result['passed'])->toBeTrue();
+            expect($result['matched'])->toContain('durable_facts');
+        });
+
+        it('passes validated entries with a category', function (): void {
+            $gate = new WriteGateService;
+            $result = $gate->evaluate([
+                'title' => 'Generic title',
+                'content' => 'Generic content',
+                'status' => 'validated',
+                'category' => 'testing',
+            ]);
+
+            expect($result['passed'])->toBeTrue();
+            expect($result['matched'])->toContain('durable_facts');
+        });
+
+        it('passes entries with durable fact language', function (): void {
+            $gate = new WriteGateService;
+            $signals = [
+                'the api contract requires json',
+                'schema definition for users table',
+                'protocol for service communication',
+                'invariant: balance must never be negative',
+                'constraint on the data model',
+            ];
+
+            foreach ($signals as $signal) {
+                $result = $gate->evaluate([
+                    'title' => 'Entry',
+                    'content' => $signal,
+                ]);
+
+                expect($result['passed'])->toBeTrue("Failed for signal: {$signal}");
+                expect($result['matched'])->toContain('durable_facts');
+            }
+        });
+    });
+
+    describe('explicit_instruction criterion', function (): void {
+        it('passes entries with instruction tags', function (): void {
+            $gate = new WriteGateService;
+            $instructionTags = ['rule', 'instruction', 'policy', 'guideline', 'standard', 'process'];
+
+            foreach ($instructionTags as $tag) {
+                $result = $gate->evaluate([
+                    'title' => 'Entry',
+                    'content' => 'Generic content here',
+                    'tags' => [$tag],
+                ]);
+
+                expect($result['passed'])->toBeTrue("Failed for tag: {$tag}");
+                expect($result['matched'])->toContain('explicit_instruction');
+            }
+        });
+
+        it('passes entries with imperative language', function (): void {
+            $gate = new WriteGateService;
+            $signals = [
+                'you must run tests before merging',
+                'do not use raw SQL queries',
+                "don't commit secrets to git",
+                'ensure that all endpoints are authenticated',
+                'make sure to validate inputs',
+                'always use prepared statements',
+                'never use eval in production',
+            ];
+
+            foreach ($signals as $signal) {
+                $result = $gate->evaluate([
+                    'title' => 'Entry',
+                    'content' => $signal,
+                ]);
+
+                expect($result['passed'])->toBeTrue("Failed for signal: {$signal}");
+                expect($result['matched'])->toContain('explicit_instruction');
+            }
+        });
+    });
+
+    describe('gate rejection', function (): void {
+        it('rejects entries that match no criteria', function (): void {
+            $gate = new WriteGateService;
+            $result = $gate->evaluate([
+                'title' => 'Misc note',
+                'content' => 'Talked to Bob about lunch plans',
+                'priority' => 'low',
+                'confidence' => 10,
+            ]);
+
+            expect($result['passed'])->toBeFalse();
+            expect($result['matched'])->toBeEmpty();
+            expect($result['reason'])->toContain('does not meet any write gate criteria');
+            expect($result['reason'])->toContain('--force');
+        });
+
+        it('includes enabled criteria names in rejection reason', function (): void {
+            $gate = new WriteGateService;
+            $result = $gate->evaluate([
+                'title' => 'Irrelevant',
+                'content' => 'Nothing useful',
+                'priority' => 'low',
+                'confidence' => 10,
+            ]);
+
+            expect($result['reason'])->toContain('Behavioral Impact');
+            expect($result['reason'])->toContain('Durable Facts');
+        });
+    });
+
+    describe('configurable criteria', function (): void {
+        it('respects disabled criteria', function (): void {
+            $gate = new WriteGateService([
+                'behavioral_impact' => false,
+                'commitment_weight' => false,
+                'decision_rationale' => false,
+                'durable_facts' => false,
+                'explicit_instruction' => true,
+            ]);
+
+            // This entry would pass behavioral_impact but it's disabled
+            $result = $gate->evaluate([
+                'title' => 'Entry',
+                'content' => 'Generic stuff',
+                'priority' => 'critical',
+            ]);
+
+            expect($result['passed'])->toBeFalse();
+            expect($result['matched'])->not->toContain('behavioral_impact');
+        });
+
+        it('passes when entry matches an enabled criterion', function (): void {
+            $gate = new WriteGateService([
+                'behavioral_impact' => false,
+                'commitment_weight' => false,
+                'decision_rationale' => true,
+                'durable_facts' => false,
+                'explicit_instruction' => false,
+            ]);
+
+            $result = $gate->evaluate([
+                'title' => 'Why we chose Qdrant',
+                'content' => 'The rationale was performance and simplicity',
+            ]);
+
+            expect($result['passed'])->toBeTrue();
+            expect($result['matched'])->toBe(['decision_rationale']);
+        });
+
+        it('rejects everything when all criteria are disabled', function (): void {
+            $gate = new WriteGateService([
+                'behavioral_impact' => false,
+                'commitment_weight' => false,
+                'decision_rationale' => false,
+                'durable_facts' => false,
+                'explicit_instruction' => false,
+            ]);
+
+            $result = $gate->evaluate([
+                'title' => 'Critical security fix',
+                'content' => 'You must apply this patch immediately because of a vulnerability',
+                'priority' => 'critical',
+                'confidence' => 100,
+                'status' => 'validated',
+                'category' => 'security',
+                'tags' => ['rule'],
+            ]);
+
+            expect($result['passed'])->toBeFalse();
+        });
+    });
+
+    describe('multiple criteria matching', function (): void {
+        it('can match multiple criteria simultaneously', function (): void {
+            $gate = new WriteGateService;
+            $result = $gate->evaluate([
+                'title' => 'Security policy',
+                'content' => 'You must always validate inputs because of injection risks',
+                'priority' => 'critical',
+                'confidence' => 95,
+                'status' => 'validated',
+                'category' => 'security',
+                'tags' => ['policy'],
+            ]);
+
+            expect($result['passed'])->toBeTrue();
+            expect(count($result['matched']))->toBeGreaterThan(1);
+        });
+    });
+
+    describe('default criteria', function (): void {
+        it('returns all five criteria enabled by default', function (): void {
+            $defaults = WriteGateService::defaultCriteria();
+
+            expect($defaults)->toBe([
+                'behavioral_impact' => true,
+                'commitment_weight' => true,
+                'decision_rationale' => true,
+                'durable_facts' => true,
+                'explicit_instruction' => true,
+            ]);
+        });
+    });
+
+    describe('getEnabledCriteria', function (): void {
+        it('returns the configured criteria', function (): void {
+            $criteria = [
+                'behavioral_impact' => true,
+                'commitment_weight' => false,
+                'decision_rationale' => true,
+                'durable_facts' => false,
+                'explicit_instruction' => true,
+            ];
+            $gate = new WriteGateService($criteria);
+
+            expect($gate->getEnabledCriteria())->toBe($criteria);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Closes #98

- **WriteGateService**: Evaluates knowledge entries against five criteria (Behavioral Impact, Commitment Weight, Decision Rationale, Durable Facts, Explicit Instruction) using signal words, metadata, and structural indicators
- **Gate integration**: The `add` command now runs entries through the write gate before persistence; entries matching none of the enabled criteria are rejected with a clear reason
- **--force bypass**: The existing `--force` flag now bypasses both the write gate and duplicate detection
- **Per-project config**: Criteria can be toggled per-project via `~/.knowledge/config.json` under `write_gate.criteria`, or via environment variables (`WRITE_GATE_BEHAVIORAL_IMPACT`, etc.)
- **Comprehensive tests**: 23 unit tests for the gate service covering all criteria, edge cases, and configurability; 3 feature tests for command integration

### Files changed

| File | Change |
|------|--------|
| `app/Services/WriteGateService.php` | New service with five evaluation criteria |
| `config/write-gate.php` | Configuration file for criteria toggles |
| `app/Commands/KnowledgeAddCommand.php` | Integrated write gate before persistence |
| `app/Providers/AppServiceProvider.php` | Registered service + user config loading |
| `tests/Unit/WriteGateServiceTest.php` | 23 unit tests for gate logic |
| `tests/Feature/KnowledgeAddCommandTest.php` | 3 integration tests + mock setup |
| `tests/Feature/Commands/KnowledgeAddCommandTest.php` | Mock setup for existing tests |

## Test plan

- [x] Unit tests for each of the five criteria (behavioral impact, commitment weight, decision rationale, durable facts, explicit instruction)
- [x] Rejection test for entries matching no criteria
- [x] Configurable criteria tests (enable/disable individual criteria)
- [x] Feature test: gate rejects low-value entries
- [x] Feature test: `--force` bypasses the gate
- [x] Feature test: entry data is passed correctly to the gate
- [x] All existing tests pass (704 passed, 5 skipped)
- [x] PHPStan level 8: no errors
- [x] Pint: all files formatted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added entry validation: knowledge entries are now evaluated against configurable quality criteria before being added to ensure they meet standards.
  * --force flag enhanced: now bypasses both the validation check and duplicate detection when creating entries.

* **Configuration**
  * New configuration settings for customizing validation criteria with environment variable support and per-project override capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->