### PR TITLE
fix: depersonalize codebase for public usability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Vector Database (Qdrant)
+QDRANT_ENABLED=true
+QDRANT_HOST=localhost
+QDRANT_PORT=6333
+EMBEDDING_PROVIDER=qdrant
+QDRANT_EMBEDDING_SERVER=http://localhost:8001
+
+# Redis Cache (optional, improves query speed)
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+# Ollama LLM (optional, for auto-tagging and query expansion)
+OLLAMA_ENABLED=false
+OLLAMA_HOST=localhost
+OLLAMA_PORT=11434
+OLLAMA_MODEL=llama3.2:3b
+
+# Centralized Sync (optional, for multi-machine knowledge sharing)
+ODIN_SYNC_ENABLED=false
+# ODIN_URL=http://your-server:8080
+# ODIN_API_TOKEN=your-token
+
+# Cloud API Sync (optional)
+# PREFRONTAL_API_URL=http://your-api:8080
+# PREFRONTAL_API_TOKEN=your-token

--- a/app/Commands/IndexCodeCommand.php
+++ b/app/Commands/IndexCodeCommand.php
@@ -24,14 +24,8 @@ class IndexCodeCommand extends Command
 
     protected $description = 'Index code files for semantic search';
 
-    private const DEFAULT_PATHS = [
-        '/home/jordan/projects/knowledge',
-        '/home/jordan/prefrontal-cortex',
-        '/home/jordan/packages/api-gateway',
-        '/home/jordan/packages/conduit-ui',
-        '/home/jordan/packages/monitor',
-        '/home/jordan/Sites/jordanpartridge.us',
-    ];
+    /** @var array<string> */
+    private const DEFAULT_PATHS = [];
 
     public function handle(CodeIndexerService $indexer): int
     {

--- a/app/Services/PatternDetectorService.php
+++ b/app/Services/PatternDetectorService.php
@@ -155,17 +155,12 @@ class PatternDetectorService
     {
         $projects = [];
 
-        // Match common project patterns
-        $patterns = [
-            '/\b(conduit-\w+)\b/i',
-            '/\b(synapse-\w+)\b/i',
-            '/\b(the-shit)\b/i',
-            '/\b(pstrax-\w+)\b/i',
-            '/\b(jordanpartridge[\w\-]*)\b/i',
-            '/\b(knowledge)\b/i',
-            '/\b(prefrontal-cortex)\b/i',
-            '/\b(vision)\b/i',
-            '/\b(odin)\b/i',
+        // Match project patterns from config, with fallback generic patterns
+        /** @var array<string> $configPatterns */
+        $configPatterns = config('search.project_patterns', []);
+
+        $patterns = $configPatterns !== [] ? $configPatterns : [
+            '/\b([\w]+-[\w]+(?:-[\w]+)*)\b/',  // hyphenated project names (e.g. my-project)
         ];
 
         foreach ($patterns as $pattern) {

--- a/config/search.php
+++ b/config/search.php
@@ -90,6 +90,21 @@ return [
     |--------------------------------------------------------------------------
     */
 
+    /*
+    |--------------------------------------------------------------------------
+    | Project Pattern Detection
+    |--------------------------------------------------------------------------
+    |
+    | Regex patterns for detecting project names in knowledge entries.
+    | Used by PatternDetectorService to extract project associations.
+    | Leave empty to use a generic hyphenated-name pattern.
+    |
+    | Example: ['/\b(my-project)\b/i', '/\b(other-app)\b/i']
+    |
+    */
+
+    'project_patterns' => [],
+
     'ollama' => [
         'enabled' => env('OLLAMA_ENABLED', true),
         'host' => env('OLLAMA_HOST', 'localhost'),

--- a/config/services.php
+++ b/config/services.php
@@ -13,7 +13,7 @@ return [
     */
 
     'prefrontal' => [
-        'url' => env('PREFRONTAL_API_URL', 'http://100.68.122.24:8080'),
+        'url' => env('PREFRONTAL_API_URL'),
         'token' => env('PREFRONTAL_API_TOKEN'),
     ],
 
@@ -29,8 +29,8 @@ return [
     */
 
     'odin' => [
-        'enabled' => env('ODIN_SYNC_ENABLED', true),
-        'url' => env('ODIN_URL', 'http://100.68.122.24:8080'),
+        'enabled' => env('ODIN_SYNC_ENABLED', false),
+        'url' => env('ODIN_URL'),
         'token' => env('ODIN_API_TOKEN', env('PREFRONTAL_API_TOKEN')),
         'timeout' => env('ODIN_TIMEOUT', 10),
         'batch_size' => env('ODIN_BATCH_SIZE', 50),

--- a/docker-compose.odin.yml
+++ b/docker-compose.odin.yml
@@ -1,11 +1,20 @@
+# Production/centralized server deployment
+# Binds to a specific network interface (e.g. Tailscale, VPN, LAN)
+#
+# Usage:
+#   BIND_ADDR=100.68.122.24 docker compose -f docker-compose.odin.yml up -d
+#
+# Set BIND_ADDR to your server's interface IP (Tailscale, LAN, etc.)
+# Defaults to 127.0.0.1 (localhost only) if not set.
+
 services:
   qdrant:
     image: qdrant/qdrant:latest
     container_name: knowledge-qdrant
     restart: unless-stopped
     ports:
-      - "100.68.122.24:6333:6333"  # HTTP API - Tailscale only
-      - "100.68.122.24:6334:6334"  # gRPC API - Tailscale only
+      - "${BIND_ADDR:-127.0.0.1}:6333:6333"
+      - "${BIND_ADDR:-127.0.0.1}:6334:6334"
     volumes:
       - qdrant_storage:/qdrant/storage
     environment:
@@ -22,7 +31,7 @@ services:
     container_name: knowledge-redis
     restart: unless-stopped
     ports:
-      - "100.68.122.24:6380:6379"  # Tailscale only
+      - "${BIND_ADDR:-127.0.0.1}:6380:6379"
     volumes:
       - redis_data:/data
     command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
@@ -39,7 +48,7 @@ services:
     container_name: knowledge-embeddings
     restart: unless-stopped
     ports:
-      - "100.68.122.24:8001:8001"  # Tailscale only
+      - "${BIND_ADDR:-127.0.0.1}:8001:8001"
     volumes:
       - embedding_cache:/root/.cache
     environment:


### PR DESCRIPTION
## Summary

Makes the package usable by anyone, not just the original developer.

- Remove hardcoded `/home/jordan/*` paths from IndexCodeCommand (empty defaults, users pass `--path`)
- Remove hardcoded Tailscale IP `100.68.122.24` from config defaults (null/localhost instead)
- Default Odin sync to **disabled** (opt-in, not opt-out)
- Replace hardcoded project name patterns (jordanpartridge, pstrax, the-shit, etc.) with config-driven `search.project_patterns`
- docker-compose.odin.yml uses `${BIND_ADDR:-127.0.0.1}` instead of hardcoded IPs
- Add `.env.example` with documented localhost defaults

## Test plan
- [ ] Tests should pass unchanged (all use mocks, don't rely on config defaults)
- [ ] PHPStan level 8 should pass
- [ ] PatternDetectorServiceTest still detects hyphenated project names (conduit-ui matches generic pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Project name pattern detection is now configurable for custom project identification.
* Service health checks added to containerized deployments for improved reliability monitoring.

**Configuration**
* Added example environment variables file for easier system setup.
* Services now support dynamic port binding configuration for flexible deployment.
* Odin synchronization service disabled by default (can be enabled if needed).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->