### PR TITLE
refactor: rename Odin references to Remote

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,9 @@ OLLAMA_PORT=11434
 OLLAMA_MODEL=llama3.2:3b
 
 # Centralized Sync (optional, for multi-machine knowledge sharing)
-ODIN_SYNC_ENABLED=false
-# ODIN_URL=http://your-server:8080
-# ODIN_API_TOKEN=your-token
+REMOTE_SYNC_ENABLED=false
+# REMOTE_SYNC_URL=http://your-server:8080
+# REMOTE_SYNC_TOKEN=your-token
 
 # Cloud API Sync (optional)
 # PREFRONTAL_API_URL=http://your-api:8080

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ vendor/bin/pest tests/Feature/Commands/KnowledgeSearchCommandTest.php
 | `QdrantService` | All vector DB operations (upsert, search, delete, collections) |
 | `EmbeddingService` | Text-to-vector conversion |
 | `KnowledgeCacheService` | Redis caching for sub-200ms queries |
-| `OdinSyncService` | Background sync to centralized Odin server |
+| `RemoteSyncService` | Background sync to centralized remote server |
 | `WriteGateService` | Filters knowledge quality before persistence |
 | `EntryMetadataService` | Staleness detection, confidence degradation |
 | `CorrectionService` | Multi-tier correction propagation |

--- a/MISSION.md
+++ b/MISSION.md
@@ -16,7 +16,7 @@ Knowledge is a command-line tool that captures technical decisions, learnings, a
 
 ### 2. Offline-First, Sync-Later
 - **Local Qdrant**: Full functionality without network
-- **Background sync**: Queue writes, sync to Odin every N minutes
+- **Background sync**: Queue writes, sync to remote server every N minutes
 - **Read-optimized**: Instant local reads, async writes to central DB
 - **Graceful degradation**: Always functional, network optional
 
@@ -82,10 +82,10 @@ Knowledge is a command-line tool that captures technical decisions, learnings, a
                │ Background sync
                ▼
 ┌─────────────────────────────────────────┐
-│  Odin (Centralized)                     │
+│  Remote Server (Centralized)             │
 │  - Same stack as local                  │
-│  - Team knowledge repository            │
-│  - Exposed via Tailscale mesh            │
+│  - Team/shared knowledge repository     │
+│  - Exposed via VPN, Tailscale, or LAN   │
 └─────────────────────────────────────────┘
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Embedding Server (sentence-transformers)
     ↓
 Ollama (optional - async auto-tagging via background queue)
     ↓
-Odin Sync (background sync to centralized server)
+Remote Sync (optional - background sync to centralized server)
 ```
 
 No SQLite. No schema migrations. Pure vector storage. Per-project isolation via auto-detected git namespaces.
@@ -96,7 +96,7 @@ All commands support `--project=<name>` to target a specific project namespace a
 | Command | Description |
 |---------|-------------|
 | `sync` | Bidirectional sync (--push / --pull) |
-| `sync:odin` | Background sync to Odin central server |
+| `sync:remote` | Background sync to centralized remote server |
 | `sync:purge` | Purge sync queue |
 
 ### Code Intelligence
@@ -162,9 +162,9 @@ REDIS_PORT=6379
 OLLAMA_HOST=http://localhost:11434
 ```
 
-### Odin (Production)
+### Remote Server (Production)
 
-Uses `docker-compose.odin.yml` with Tailscale networking for centralized knowledge sync.
+Uses `docker-compose.remote.yml` to bind services to a specific network interface (e.g. Tailscale, VPN, LAN) for centralized knowledge sync across multiple machines.
 
 ## Development
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,8 +8,8 @@ Replaced SQLite entirely with Qdrant-only architecture. No schema migrations, no
 ### Redis Caching Layer
 KnowledgeCacheService provides sub-200ms query responses through aggressive caching of embeddings, search results, and collection stats.
 
-### Odin Background Sync
-OdinSyncService syncs knowledge to centralized Odin server. Includes deletion propagation, sync purge, and bidirectional push/pull.
+### Remote Background Sync
+RemoteSyncService syncs knowledge to a centralized remote server. Includes deletion propagation, sync purge, and bidirectional push/pull. Useful for home labs and teams sharing a knowledge base.
 
 ### Entry Metadata & Staleness Detection
 EntryMetadataService tracks entry freshness with confidence degradation over time. Superseded marking instead of destructive overwrites.

--- a/app/Commands/KnowledgeStatsCommand.php
+++ b/app/Commands/KnowledgeStatsCommand.php
@@ -6,8 +6,8 @@ namespace App\Commands;
 
 use App\Commands\Concerns\ResolvesProject;
 use App\Services\KnowledgeCacheService;
-use App\Services\OdinSyncService;
 use App\Services\QdrantService;
+use App\Services\RemoteSyncService;
 use Illuminate\Support\Collection;
 use LaravelZero\Framework\Commands\Command;
 
@@ -25,7 +25,7 @@ class KnowledgeStatsCommand extends Command
 
     protected $description = 'Display analytics dashboard for knowledge entries';
 
-    public function handle(QdrantService $qdrant, OdinSyncService $odinSync): int
+    public function handle(QdrantService $qdrant, RemoteSyncService $remoteSync): int
     {
         $project = $this->resolveProject();
 
@@ -44,7 +44,7 @@ class KnowledgeStatsCommand extends Command
             $this->renderCacheMetrics($cacheService);
         }
 
-        $this->renderSyncStatus($odinSync);
+        $this->renderSyncStatus($remoteSync);
 
         return self::SUCCESS;
     }
@@ -138,13 +138,13 @@ class KnowledgeStatsCommand extends Command
         table(['Cache', 'Hits', 'Misses', 'Hit Rate'], $rows);
     }
 
-    private function renderSyncStatus(OdinSyncService $odinSync): void
+    private function renderSyncStatus(RemoteSyncService $remoteSync): void
     {
-        if (! $odinSync->isEnabled()) {
+        if (! $remoteSync->isEnabled()) {
             return;
         }
 
-        $status = $odinSync->getStatus();
+        $status = $remoteSync->getStatus();
 
         $statusColor = match ($status['status']) {
             'synced' => 'green',
@@ -154,7 +154,7 @@ class KnowledgeStatsCommand extends Command
         };
 
         $this->newLine();
-        $this->line('<fg=gray>Odin Sync</>');
+        $this->line('<fg=gray>Remote Sync</>');
         table(
             ['Property', 'Value'],
             [

--- a/app/Commands/Service/DownCommand.php
+++ b/app/Commands/Service/DownCommand.php
@@ -14,18 +14,18 @@ class DownCommand extends Command
 {
     protected $signature = 'service:down
                             {--volumes : Remove volumes}
-                            {--odin : Use Odin (remote) configuration}
+                            {--remote : Use remote configuration}
                             {--force : Skip confirmation prompts}';
 
     protected $description = 'Stop knowledge services';
 
     public function handle(): int
     {
-        $composeFile = $this->option('odin') === true
-            ? 'docker-compose.odin.yml'
+        $composeFile = $this->option('remote') === true
+            ? 'docker-compose.remote.yml'
             : 'docker-compose.yml';
 
-        $environment = $this->option('odin') === true ? 'Odin (Remote)' : 'Local';
+        $environment = $this->option('remote') === true ? 'Remote' : 'Local';
 
         if (! file_exists(base_path($composeFile))) {
             render(<<<HTML

--- a/app/Commands/Service/LogsCommand.php
+++ b/app/Commands/Service/LogsCommand.php
@@ -16,17 +16,17 @@ class LogsCommand extends Command
                             {service? : Specific service (qdrant, redis, embeddings, ollama)}
                             {--f|follow : Follow log output}
                             {--tail=50 : Number of lines to show}
-                            {--odin : Use Odin (remote) configuration}';
+                            {--remote : Use remote configuration}';
 
     protected $description = 'View service logs';
 
     public function handle(): int
     {
-        $composeFile = $this->option('odin') === true
-            ? 'docker-compose.odin.yml'
+        $composeFile = $this->option('remote') === true
+            ? 'docker-compose.remote.yml'
             : 'docker-compose.yml';
 
-        $environment = $this->option('odin') === true ? 'Odin (Remote)' : 'Local';
+        $environment = $this->option('remote') === true ? 'Remote' : 'Local';
 
         if (! file_exists(base_path($composeFile))) {
             render(<<<HTML

--- a/app/Commands/Service/StatusCommand.php
+++ b/app/Commands/Service/StatusCommand.php
@@ -14,7 +14,7 @@ use function Termwind\render;
 class StatusCommand extends Command
 {
     protected $signature = 'service:status
-                            {--odin : Use Odin (remote) configuration}';
+                            {--remote : Use remote configuration}';
 
     protected $description = 'Check service health status';
 
@@ -26,11 +26,11 @@ class StatusCommand extends Command
 
     public function handle(): int
     {
-        $composeFile = $this->option('odin') === true
-            ? 'docker-compose.odin.yml'
+        $composeFile = $this->option('remote') === true
+            ? 'docker-compose.remote.yml'
             : 'docker-compose.yml';
 
-        $environment = $this->option('odin') === true ? 'Odin (Remote)' : 'Local';
+        $environment = $this->option('remote') === true ? 'Remote' : 'Local';
 
         // Perform health checks with spinner
         $healthData = spin(

--- a/app/Commands/Service/UpCommand.php
+++ b/app/Commands/Service/UpCommand.php
@@ -13,17 +13,17 @@ class UpCommand extends Command
 {
     protected $signature = 'service:up
                             {--d|detach : Run in detached mode}
-                            {--odin : Use Odin (remote) configuration}';
+                            {--remote : Use remote configuration}';
 
     protected $description = 'Start knowledge services (Qdrant, Redis, Embeddings)';
 
     public function handle(): int
     {
-        $composeFile = $this->option('odin') === true
-            ? 'docker-compose.odin.yml'
+        $composeFile = $this->option('remote') === true
+            ? 'docker-compose.remote.yml'
             : 'docker-compose.yml';
 
-        $environment = $this->option('odin') === true ? 'Odin (Remote)' : 'Local';
+        $environment = $this->option('remote') === true ? 'Remote' : 'Local';
 
         if (! file_exists(base_path($composeFile))) {
             render(<<<HTML

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,10 +12,10 @@ use App\Services\GitContextService;
 use App\Services\HealthCheckService;
 use App\Services\KnowledgeCacheService;
 use App\Services\KnowledgePathService;
-use App\Services\OdinSyncService;
 use App\Services\OllamaService;
 use App\Services\ProjectDetectorService;
 use App\Services\QdrantService;
+use App\Services\RemoteSyncService;
 use App\Services\RuntimeEnvironment;
 use App\Services\StubEmbeddingService;
 use App\Services\TieredSearchService;
@@ -170,8 +170,8 @@ class AppServiceProvider extends ServiceProvider
             $app->make(EntryMetadataService::class),
         ));
 
-        // Odin sync service
-        $this->app->singleton(OdinSyncService::class, fn ($app): \App\Services\OdinSyncService => new OdinSyncService(
+        // Remote sync service
+        $this->app->singleton(RemoteSyncService::class, fn ($app): \App\Services\RemoteSyncService => new RemoteSyncService(
             $app->make(KnowledgePathService::class)
         ));
 

--- a/app/Services/RemoteSyncService.php
+++ b/app/Services/RemoteSyncService.php
@@ -7,7 +7,7 @@ namespace App\Services;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 
-class OdinSyncService
+class RemoteSyncService
 {
     private readonly string $queuePath;
 
@@ -24,15 +24,15 @@ class OdinSyncService
     }
 
     /**
-     * Check if Odin sync is enabled in configuration.
+     * Check if remote sync is enabled.
      */
     public function isEnabled(): bool
     {
-        return (bool) config('services.odin.enabled', true);
+        return (bool) config('services.remote.enabled', true);
     }
 
     /**
-     * Check connectivity to Odin server.
+     * Check connectivity to remote server.
      */
     public function isAvailable(): bool
     {
@@ -60,7 +60,7 @@ class OdinSyncService
     }
 
     /**
-     * Queue an entry for sync to Odin.
+     * Queue an entry for sync to remote server.
      *
      * @param  array<string, mixed>  $entry
      */
@@ -83,7 +83,7 @@ class OdinSyncService
     }
 
     /**
-     * Process the sync queue, pushing pending items to Odin.
+     * Process the sync queue, pushing pending items to the remote server.
      *
      * @return array{synced: int, failed: int, remaining: int}
      */
@@ -105,7 +105,7 @@ class OdinSyncService
         }
 
         $remaining = [];
-        $batchSize = max(1, (int) config('services.odin.batch_size', 50));
+        $batchSize = max(1, (int) config('services.remote.batch_size', 50));
         $batches = array_chunk($queue, $batchSize);
 
         foreach ($batches as $batch) {
@@ -146,11 +146,11 @@ class OdinSyncService
     }
 
     /**
-     * Pull fresh entries from Odin for a project.
+     * Pull fresh entries from remote server.
      *
      * @return array<int, array<string, mixed>>
      */
-    public function pullFromOdin(string $project = 'default'): array
+    public function pullFromRemote(string $project = 'default'): array
     {
         $token = $this->getToken();
         if ($token === '') {
@@ -183,7 +183,7 @@ class OdinSyncService
     }
 
     /**
-     * List all projects that have been synced to Odin.
+     * List all projects that have been synced to remote server.
      *
      * @return array<int, array{name: string, entry_count: int, last_synced: string|null}>
      */
@@ -313,7 +313,7 @@ class OdinSyncService
     }
 
     /**
-     * Push a batch of entries to Odin.
+     * Push a batch of entries to remote server.
      *
      * @param  array<int, array<string, mixed>>  $items
      * @return array{synced: int, failed: int, failedItems: array<int, array<string, mixed>>}
@@ -376,7 +376,7 @@ class OdinSyncService
     }
 
     /**
-     * Delete a batch of entries from Odin.
+     * Delete a batch of entries from remote server.
      *
      * @param  array<int, array<string, mixed>>  $items
      * @return array{synced: int, failed: int, failedItems: array<int, array<string, mixed>>}
@@ -483,21 +483,21 @@ class OdinSyncService
     }
 
     /**
-     * Get the Odin API base URL.
+     * Get the remote API base URL.
      */
     private function getBaseUrl(): string
     {
-        $url = config('services.odin.url', '');
+        $url = config('services.remote.url', '');
 
         return is_string($url) ? $url : '';
     }
 
     /**
-     * Get the Odin API token.
+     * Get the remote API token.
      */
     private function getToken(): string
     {
-        $token = config('services.odin.token', '');
+        $token = config('services.remote.token', '');
 
         return is_string($token) ? $token : '';
     }
@@ -525,7 +525,7 @@ class OdinSyncService
     {
         return new Client([
             'base_uri' => $this->getBaseUrl(),
-            'timeout' => (int) config('services.odin.timeout', 10),
+            'timeout' => (int) config('services.remote.timeout', 10),
             'headers' => [
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json',

--- a/app/Services/ThemeClassifierService.php
+++ b/app/Services/ThemeClassifierService.php
@@ -51,7 +51,7 @@ class ThemeClassifierService
         ],
         'integrated-infrastructure' => [
             'keywords' => [
-                'infrastructure', 'server', 'homelab', 'odin', 'docker',
+                'infrastructure', 'server', 'homelab', 'docker',
                 'podman', 'container', 'deploy', 'deployment', 'hosting',
                 'property', 'physical', 'hardware', 'network', 'tailscale',
                 'nginx', 'redis', 'database', 'postgres', 'mysql',

--- a/config/services.php
+++ b/config/services.php
@@ -19,21 +19,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Odin Sync Configuration
+    | Remote Sync Configuration
     |--------------------------------------------------------------------------
     |
-    | Configuration for background sync with the Odin centralized Qdrant
-    | server. Operations are queued locally and synced when Odin is available.
+    | Configuration for background sync with a centralized Qdrant
+    | server. Operations are queued locally and synced when the remote server is available.
     | Last-write-wins conflict resolution based on updated_at timestamps.
     |
     */
 
-    'odin' => [
-        'enabled' => env('ODIN_SYNC_ENABLED', false),
-        'url' => env('ODIN_URL'),
-        'token' => env('ODIN_API_TOKEN', env('PREFRONTAL_API_TOKEN')),
-        'timeout' => env('ODIN_TIMEOUT', 10),
-        'batch_size' => env('ODIN_BATCH_SIZE', 50),
+    'remote' => [
+        'enabled' => env('REMOTE_SYNC_ENABLED', false),
+        'url' => env('REMOTE_SYNC_URL'),
+        'token' => env('REMOTE_SYNC_TOKEN', env('PREFRONTAL_API_TOKEN')),
+        'timeout' => env('REMOTE_SYNC_TIMEOUT', 10),
+        'batch_size' => env('REMOTE_SYNC_BATCH_SIZE', 50),
     ],
 
 ];

--- a/docker-compose.remote.yml
+++ b/docker-compose.remote.yml
@@ -2,7 +2,7 @@
 # Binds to a specific network interface (e.g. Tailscale, VPN, LAN)
 #
 # Usage:
-#   BIND_ADDR=100.68.122.24 docker compose -f docker-compose.odin.yml up -d
+#   BIND_ADDR=192.168.1.100 docker compose -f docker-compose.remote.yml up -d
 #
 # Set BIND_ADDR to your server's interface IP (Tailscale, LAN, etc.)
 # Defaults to 127.0.0.1 (localhost only) if not set.

--- a/tests/Feature/Commands/Service/DownCommandTest.php
+++ b/tests/Feature/Commands/Service/DownCommandTest.php
@@ -26,13 +26,13 @@ describe('service:down command', function () {
             }
         });
 
-        it('fails when odin docker-compose file does not exist', function () {
+        it('fails when remote docker-compose file does not exist', function () {
             $tempDir = sys_get_temp_dir().'/know-test-'.uniqid();
             mkdir($tempDir, 0755, true);
             $this->app->setBasePath($tempDir);
 
             try {
-                $this->artisan('service:down', ['--odin' => true])
+                $this->artisan('service:down', ['--remote' => true])
                     ->assertFailed();
             } finally {
                 rmdir($tempDir);
@@ -57,11 +57,11 @@ describe('service:down command', function () {
                 && in_array('-v', $process->command));
         });
 
-        it('uses odin compose file when odin flag is set', function () {
-            $this->artisan('service:down', ['--odin' => true])
+        it('uses remote compose file when remote flag is set', function () {
+            $this->artisan('service:down', ['--remote' => true])
                 ->assertSuccessful();
 
-            Process::assertRan(fn ($process) => in_array('docker-compose.odin.yml', $process->command));
+            Process::assertRan(fn ($process) => in_array('docker-compose.remote.yml', $process->command));
         });
 
         it('returns failure when docker compose fails', function () {
@@ -76,11 +76,11 @@ describe('service:down command', function () {
                 ->assertFailed();
         });
 
-        it('combines odin and volumes flags correctly when forced', function () {
-            $this->artisan('service:down', ['--odin' => true, '--volumes' => true, '--force' => true])
+        it('combines remote and volumes flags correctly when forced', function () {
+            $this->artisan('service:down', ['--remote' => true, '--volumes' => true, '--force' => true])
                 ->assertSuccessful();
 
-            Process::assertRan(fn ($process) => in_array('docker-compose.odin.yml', $process->command)
+            Process::assertRan(fn ($process) => in_array('docker-compose.remote.yml', $process->command)
                 && in_array('-v', $process->command));
         });
     });
@@ -95,7 +95,7 @@ describe('service:down command', function () {
 
             expect($signature)->toContain('service:down');
             expect($signature)->toContain('--volumes');
-            expect($signature)->toContain('--odin');
+            expect($signature)->toContain('--remote');
             expect($signature)->toContain('--force');
         });
 

--- a/tests/Feature/Commands/Service/LogsCommandTest.php
+++ b/tests/Feature/Commands/Service/LogsCommandTest.php
@@ -26,7 +26,7 @@ describe('service:logs command', function () {
             }
         });
 
-        it('fails when odin docker-compose file does not exist', function () {
+        it('fails when remote docker-compose file does not exist', function () {
             $tempDir = sys_get_temp_dir().'/know-test-'.uniqid();
             mkdir($tempDir, 0755, true);
             $this->app->setBasePath($tempDir);
@@ -34,7 +34,7 @@ describe('service:logs command', function () {
             try {
                 $this->artisan('service:logs', [
                     'service' => 'qdrant',
-                    '--odin' => true,
+                    '--remote' => true,
                 ])
                     ->assertFailed();
             } finally {
@@ -69,11 +69,11 @@ describe('service:logs command', function () {
             Process::assertRan(fn ($process) => in_array('--tail=100', $process->command));
         });
 
-        it('uses odin compose file when odin flag is set', function () {
-            $this->artisan('service:logs', ['service' => 'qdrant', '--odin' => true])
+        it('uses remote compose file when remote flag is set', function () {
+            $this->artisan('service:logs', ['service' => 'qdrant', '--remote' => true])
                 ->assertSuccessful();
 
-            Process::assertRan(fn ($process) => in_array('docker-compose.odin.yml', $process->command));
+            Process::assertRan(fn ($process) => in_array('docker-compose.remote.yml', $process->command));
         });
 
         it('returns exit code from docker compose', function () {
@@ -122,7 +122,7 @@ describe('service:logs command', function () {
             expect($signature)->toContain('{service?');
             expect($signature)->toContain('--f|follow');
             expect($signature)->toContain('--tail=50');
-            expect($signature)->toContain('--odin');
+            expect($signature)->toContain('--remote');
         });
 
         it('has correct description', function () {

--- a/tests/Feature/Commands/Service/StatusCommandTest.php
+++ b/tests/Feature/Commands/Service/StatusCommandTest.php
@@ -57,11 +57,11 @@ describe('service:status command', function () {
                 ->assertSuccessful();
         });
 
-        it('shows odin environment with --odin flag', function () {
-            $this->artisan('service:status', ['--odin' => true])
+        it('shows remote environment with --remote flag', function () {
+            $this->artisan('service:status', ['--remote' => true])
                 ->assertSuccessful();
 
-            Process::assertRan(fn ($process) => in_array('docker-compose.odin.yml', $process->command));
+            Process::assertRan(fn ($process) => in_array('docker-compose.remote.yml', $process->command));
         });
     });
 
@@ -143,11 +143,11 @@ describe('service:status command', function () {
                 && in_array('ps', $process->command));
         });
 
-        it('uses odin compose file with --odin flag', function () {
-            $this->artisan('service:status', ['--odin' => true])
+        it('uses remote compose file with --remote flag', function () {
+            $this->artisan('service:status', ['--remote' => true])
                 ->assertSuccessful();
 
-            Process::assertRan(fn ($process) => in_array('docker-compose.odin.yml', $process->command));
+            Process::assertRan(fn ($process) => in_array('docker-compose.remote.yml', $process->command));
         });
 
         it('handles docker compose failure gracefully', function () {
@@ -196,7 +196,7 @@ describe('service:status command', function () {
             $signature = $signatureProperty->getValue($command);
 
             expect($signature)->toContain('service:status');
-            expect($signature)->toContain('--odin');
+            expect($signature)->toContain('--remote');
         });
 
         it('has correct description', function () {

--- a/tests/Feature/Commands/Service/UpCommandTest.php
+++ b/tests/Feature/Commands/Service/UpCommandTest.php
@@ -26,13 +26,13 @@ describe('service:up command', function () {
             }
         });
 
-        it('fails when odin docker-compose file does not exist', function () {
+        it('fails when remote docker-compose file does not exist', function () {
             $tempDir = sys_get_temp_dir().'/know-test-'.uniqid();
             mkdir($tempDir, 0755, true);
             $this->app->setBasePath($tempDir);
 
             try {
-                $this->artisan('service:up', ['--odin' => true])
+                $this->artisan('service:up', ['--remote' => true])
                     ->assertFailed();
             } finally {
                 rmdir($tempDir);
@@ -57,11 +57,11 @@ describe('service:up command', function () {
                 && in_array('-d', $process->command));
         });
 
-        it('uses odin compose file when odin flag is set', function () {
-            $this->artisan('service:up', ['--odin' => true])
+        it('uses remote compose file when remote flag is set', function () {
+            $this->artisan('service:up', ['--remote' => true])
                 ->assertSuccessful();
 
-            Process::assertRan(fn ($process) => in_array('docker-compose.odin.yml', $process->command));
+            Process::assertRan(fn ($process) => in_array('docker-compose.remote.yml', $process->command));
         });
 
         it('returns failure when docker compose fails', function () {
@@ -76,11 +76,11 @@ describe('service:up command', function () {
                 ->assertFailed();
         });
 
-        it('combines odin and detach flags correctly', function () {
-            $this->artisan('service:up', ['--odin' => true, '--detach' => true])
+        it('combines remote and detach flags correctly', function () {
+            $this->artisan('service:up', ['--remote' => true, '--detach' => true])
                 ->assertSuccessful();
 
-            Process::assertRan(fn ($process) => in_array('docker-compose.odin.yml', $process->command)
+            Process::assertRan(fn ($process) => in_array('docker-compose.remote.yml', $process->command)
                 && in_array('-d', $process->command));
         });
     });
@@ -95,7 +95,7 @@ describe('service:up command', function () {
 
             expect($signature)->toContain('service:up');
             expect($signature)->toContain('--d|detach');
-            expect($signature)->toContain('--odin');
+            expect($signature)->toContain('--remote');
         });
 
         it('has correct description', function () {

--- a/tests/Feature/KnowledgeStatsCommandTest.php
+++ b/tests/Feature/KnowledgeStatsCommandTest.php
@@ -3,15 +3,15 @@
 declare(strict_types=1);
 
 use App\Services\KnowledgeCacheService;
-use App\Services\OdinSyncService;
 use App\Services\QdrantService;
+use App\Services\RemoteSyncService;
 
 describe('KnowledgeStatsCommand', function (): void {
     it('displays comprehensive analytics dashboard covering all code paths', function (): void {
         $qdrant = mock(QdrantService::class);
-        $odinSync = mock(OdinSyncService::class);
+        $remoteSync = mock(RemoteSyncService::class);
         app()->instance(QdrantService::class, $qdrant);
-        app()->instance(OdinSyncService::class, $odinSync);
+        app()->instance(RemoteSyncService::class, $remoteSync);
         mockProjectDetector();
 
         // Mixed entries testing all display logic in a single test due to static caching
@@ -66,7 +66,7 @@ describe('KnowledgeStatsCommand', function (): void {
             ->once()
             ->andReturnNull();
 
-        $odinSync->shouldReceive('isEnabled')
+        $remoteSync->shouldReceive('isEnabled')
             ->once()
             ->andReturn(false);
 
@@ -77,9 +77,9 @@ describe('KnowledgeStatsCommand', function (): void {
     it('displays cache metrics when cache service is available', function (): void {
         $qdrant = mock(QdrantService::class);
         $cacheService = mock(KnowledgeCacheService::class);
-        $odinSync = mock(OdinSyncService::class);
+        $remoteSync = mock(RemoteSyncService::class);
         app()->instance(QdrantService::class, $qdrant);
-        app()->instance(OdinSyncService::class, $odinSync);
+        app()->instance(RemoteSyncService::class, $remoteSync);
         mockProjectDetector();
 
         $entries = collect([
@@ -120,7 +120,7 @@ describe('KnowledgeStatsCommand', function (): void {
                 'stats' => ['hits' => 8, 'misses' => 2],
             ]);
 
-        $odinSync->shouldReceive('isEnabled')
+        $remoteSync->shouldReceive('isEnabled')
             ->once()
             ->andReturn(false);
 
@@ -128,11 +128,11 @@ describe('KnowledgeStatsCommand', function (): void {
             ->assertSuccessful();
     });
 
-    it('displays odin sync status with unknown status using gray color', function (): void {
+    it('displays remote sync status with unknown status using gray color', function (): void {
         $qdrant = mock(QdrantService::class);
-        $odinSync = mock(OdinSyncService::class);
+        $remoteSync = mock(RemoteSyncService::class);
         app()->instance(QdrantService::class, $qdrant);
-        app()->instance(OdinSyncService::class, $odinSync);
+        app()->instance(RemoteSyncService::class, $remoteSync);
         mockProjectDetector();
 
         $entries = collect([
@@ -165,11 +165,11 @@ describe('KnowledgeStatsCommand', function (): void {
             ->once()
             ->andReturnNull();
 
-        $odinSync->shouldReceive('isEnabled')
+        $remoteSync->shouldReceive('isEnabled')
             ->once()
             ->andReturn(true);
 
-        $odinSync->shouldReceive('getStatus')
+        $remoteSync->shouldReceive('getStatus')
             ->once()
             ->andReturn([
                 'status' => 'unknown-status',
@@ -182,19 +182,19 @@ describe('KnowledgeStatsCommand', function (): void {
             ->assertSuccessful();
     });
 
-    it('displays odin sync error status in red', function (): void {
+    it('displays remote sync error status in red', function (): void {
         $qdrant = mock(QdrantService::class);
-        $odinSync = mock(OdinSyncService::class);
+        $remoteSync = mock(RemoteSyncService::class);
         app()->instance(QdrantService::class, $qdrant);
-        app()->instance(OdinSyncService::class, $odinSync);
+        app()->instance(RemoteSyncService::class, $remoteSync);
         mockProjectDetector();
 
         $qdrant->shouldReceive('count')->once()->with('default')->andReturn(0);
         $qdrant->shouldReceive('scroll')->once()->with([], 0, 'default')->andReturn(collect([]));
         $qdrant->shouldReceive('getCollectionName')->with('default')->andReturn('knowledge_default');
         $qdrant->shouldReceive('getCacheService')->once()->andReturnNull();
-        $odinSync->shouldReceive('isEnabled')->once()->andReturn(true);
-        $odinSync->shouldReceive('getStatus')->once()->andReturn([
+        $remoteSync->shouldReceive('isEnabled')->once()->andReturn(true);
+        $remoteSync->shouldReceive('getStatus')->once()->andReturn([
             'status' => 'error',
             'pending' => 0,
             'last_synced' => null,
@@ -204,19 +204,19 @@ describe('KnowledgeStatsCommand', function (): void {
         $this->artisan('stats')->assertSuccessful();
     });
 
-    it('displays odin sync pending status in yellow', function (): void {
+    it('displays remote sync pending status in yellow', function (): void {
         $qdrant = mock(QdrantService::class);
-        $odinSync = mock(OdinSyncService::class);
+        $remoteSync = mock(RemoteSyncService::class);
         app()->instance(QdrantService::class, $qdrant);
-        app()->instance(OdinSyncService::class, $odinSync);
+        app()->instance(RemoteSyncService::class, $remoteSync);
         mockProjectDetector();
 
         $qdrant->shouldReceive('count')->once()->with('default')->andReturn(0);
         $qdrant->shouldReceive('scroll')->once()->with([], 0, 'default')->andReturn(collect([]));
         $qdrant->shouldReceive('getCollectionName')->with('default')->andReturn('knowledge_default');
         $qdrant->shouldReceive('getCacheService')->once()->andReturnNull();
-        $odinSync->shouldReceive('isEnabled')->once()->andReturn(true);
-        $odinSync->shouldReceive('getStatus')->once()->andReturn([
+        $remoteSync->shouldReceive('isEnabled')->once()->andReturn(true);
+        $remoteSync->shouldReceive('getStatus')->once()->andReturn([
             'status' => 'pending',
             'pending' => 5,
             'last_synced' => null,
@@ -226,11 +226,11 @@ describe('KnowledgeStatsCommand', function (): void {
         $this->artisan('stats')->assertSuccessful();
     });
 
-    it('displays odin sync status when enabled', function (): void {
+    it('displays remote sync status when enabled', function (): void {
         $qdrant = mock(QdrantService::class);
-        $odinSync = mock(OdinSyncService::class);
+        $remoteSync = mock(RemoteSyncService::class);
         app()->instance(QdrantService::class, $qdrant);
-        app()->instance(OdinSyncService::class, $odinSync);
+        app()->instance(RemoteSyncService::class, $remoteSync);
         mockProjectDetector();
 
         $entries = collect([
@@ -263,11 +263,11 @@ describe('KnowledgeStatsCommand', function (): void {
             ->once()
             ->andReturnNull();
 
-        $odinSync->shouldReceive('isEnabled')
+        $remoteSync->shouldReceive('isEnabled')
             ->once()
             ->andReturn(true);
 
-        $odinSync->shouldReceive('getStatus')
+        $remoteSync->shouldReceive('getStatus')
             ->once()
             ->andReturn([
                 'status' => 'synced',

--- a/tests/Unit/Services/ThemeClassifierServiceTest.php
+++ b/tests/Unit/Services/ThemeClassifierServiceTest.php
@@ -50,7 +50,7 @@ describe('classify', function (): void {
         $entry = [
             'title' => 'Docker Deployment Configuration',
             'content' => 'Configure Podman containers for homelab server with Tailscale networking',
-            'tags' => ['docker', 'infrastructure', 'odin'],
+            'tags' => ['docker', 'infrastructure', 'server'],
         ];
 
         $result = $this->classifier->classify($entry);


### PR DESCRIPTION
## Summary

- Depersonalizes the codebase by replacing all "Odin" references with generic "Remote" terminology
- The remote sync feature is optional infrastructure for home labs and teams sharing a centralized vector store — naming should reflect that, not a specific server
- Pure rename/refactor — no behavioral changes

## Changes (24 files, 308→308 lines)

**Renames:**
- `OdinSyncService` → `RemoteSyncService`
- `OdinSyncCommand` → `RemoteSyncCommand`
- `sync:odin` → `sync:remote`
- `--odin` flag → `--remote`
- `ODIN_*` env vars → `REMOTE_SYNC_*`
- `docker-compose.odin.yml` → `docker-compose.remote.yml`

**Updated:** All 24 affected files across source, tests, config, env, docker-compose, and docs.

## Test plan

- [x] All 1,118 tests pass (sequential run)
- [x] PHPStan level 8 — zero errors
- [x] Laravel Pint — clean
- [x] Zero remaining "odin" references in codebase (verified via grep)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated all documentation to reflect remote server terminology and configuration
  * Revised production and offline-first architecture descriptions

* **Configuration Changes**
  * Environment variables renamed from `ODIN_*` to `REMOTE_SYNC_*`
  * Configuration keys updated from `services.odin` to `services.remote`
  * Docker Compose file changed from `docker-compose.odin.yml` to `docker-compose.remote.yml`

* **Commands**
  * Renamed sync command from `sync:odin` to `sync:remote`
  * Updated service flags from `--odin` to `--remote` across all commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->