### PR TITLE
refactor: remove ChromaDB references and replace with Qdrant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 
 # Default target
 help:
-	@echo "Knowledge ChromaDB Management"
+	@echo "Knowledge Vector Database Management"
 	@echo ""
 	@echo "Usage:"
-	@echo "  make up        - Start ChromaDB and embedding server"
+	@echo "  make up        - Start Qdrant and embedding server"
 	@echo "  make down      - Stop all services"
 	@echo "  make logs      - Tail service logs"
 	@echo "  make status    - Check service status"
@@ -16,18 +16,17 @@ help:
 
 # Start services
 up:
-	@echo "Starting ChromaDB and embedding server..."
+	@echo "Starting Qdrant and embedding server..."
 	@docker compose up -d
 	@echo "Waiting for services to be healthy..."
 	@sleep 5
 	@docker compose ps
 	@echo ""
 	@echo "Services ready!"
-	@echo "  ChromaDB:   http://localhost:8000"
+	@echo "  Qdrant:     http://localhost:6333"
 	@echo "  Embeddings: http://localhost:8001"
 	@echo ""
 	@echo "Enable in .env:"
-	@echo "  CHROMADB_ENABLED=true"
 	@echo "  SEMANTIC_SEARCH_ENABLED=true"
 
 # Stop services
@@ -43,7 +42,7 @@ status:
 	@docker compose ps
 	@echo ""
 	@echo "Health checks:"
-	@curl -sf http://localhost:8000/api/v1/heartbeat > /dev/null && echo "  ChromaDB:   OK" || echo "  ChromaDB:   NOT RUNNING"
+	@curl -sf http://localhost:6333/collections > /dev/null && echo "  Qdrant:     OK" || echo "  Qdrant:     NOT RUNNING"
 	@curl -sf http://localhost:8001/health > /dev/null && echo "  Embeddings: OK" || echo "  Embeddings: NOT RUNNING"
 
 # Restart services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,21 @@
 services:
-  chromadb:
-    image: chromadb/chroma:latest
-    container_name: knowledge-chromadb
+  qdrant:
+    image: qdrant/qdrant:latest
+    container_name: knowledge-qdrant
     restart: unless-stopped
     ports:
-      - "8000:8000"
+      - "6333:6333"
+      - "6334:6334"
     volumes:
-      - chromadb_data:/data
+      - qdrant_storage:/qdrant/storage
     environment:
-      - IS_PERSISTENT=TRUE
-      - ANONYMIZED_TELEMETRY=FALSE
+      - QDRANT__SERVICE__HTTP_PORT=6333
+      - QDRANT__SERVICE__GRPC_PORT=6334
+    healthcheck:
+      test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/6333"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
   embedding-server:
     build:
@@ -22,8 +28,8 @@ services:
     volumes:
       - embedding_cache:/root/.cache
     depends_on:
-      - chromadb
+      - qdrant
 
 volumes:
-  chromadb_data:
+  qdrant_storage:
   embedding_cache:

--- a/tests/Feature/AppServiceProviderTest.php
+++ b/tests/Feature/AppServiceProviderTest.php
@@ -34,16 +34,6 @@ describe('AppServiceProvider', function (): void {
         expect($service)->toBeInstanceOf(StubEmbeddingService::class);
     });
 
-    it('registers EmbeddingService when provider is chromadb', function (): void {
-        config(['search.embedding_provider' => 'chromadb']);
-
-        app()->forgetInstance(EmbeddingServiceInterface::class);
-
-        $service = app(EmbeddingServiceInterface::class);
-
-        expect($service)->toBeInstanceOf(EmbeddingService::class);
-    });
-
     it('registers EmbeddingService when provider is qdrant', function (): void {
         config(['search.embedding_provider' => 'qdrant']);
 


### PR DESCRIPTION
## Summary

- **Remove ChromaDB service** from docker-compose.yml
- **Add Qdrant service** with proper configuration (ports 6333/6334, health checks)
- **Update Makefile** to reference Qdrant instead of ChromaDB  
- **Remove ChromaDB test** from AppServiceProviderTest
- **Add synapse-sentinel/gate badge** to README

## Breaking Changes

- Docker compose now uses Qdrant instead of ChromaDB
- Port mapping: Qdrant on 6333/6334 (was ChromaDB on 8000)
- Embedding server now depends on qdrant service

## Context

ChromaDB was legacy dependency. Qdrant provides:
- Better Rust-based performance
- Production reliability  
- Consistent with existing codebase architecture

## Testing

- ✅ AppServiceProvider tests pass
- ✅ Docker compose configuration validated
- ✅ Makefile updated with correct health checks

All ChromaDB references removed while maintaining full functionality with Qdrant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Vector database service now uses Qdrant, accessible on port 6333 instead of port 8000
  * Updated startup messages, help text, and health check endpoints to reflect the new service
  * Updated Docker configuration and storage volumes for the new database backend

<!-- end of auto-generated comment: release notes by coderabbit.ai -->