### PR TITLE
feat: native PHP MCP server via laravel/mcp

### DIFF
--- a/app/Mcp/Servers/KnowledgeServer.php
+++ b/app/Mcp/Servers/KnowledgeServer.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Servers;
+
+use App\Mcp\Tools\ContextTool;
+use App\Mcp\Tools\CorrectTool;
+use App\Mcp\Tools\RecallTool;
+use App\Mcp\Tools\RememberTool;
+use App\Mcp\Tools\StatsTool;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Attributes\Instructions;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Attributes\Version;
+
+#[Name('Knowledge')]
+#[Version('1.0.0')]
+#[Instructions('Semantic knowledge base with vector search. Use `recall` to search, `remember` to capture discoveries, `correct` to fix wrong knowledge, `context` to load project-relevant entries, and `stats` for health checks. All tools auto-detect the current project from git context.')]
+class KnowledgeServer extends Server
+{
+    protected array $tools = [
+        RecallTool::class,
+        RememberTool::class,
+        CorrectTool::class,
+        ContextTool::class,
+        StatsTool::class,
+    ];
+
+    protected array $resources = [];
+
+    protected array $prompts = [];
+}

--- a/app/Mcp/Tools/ContextTool.php
+++ b/app/Mcp/Tools/ContextTool.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools;
+
+use App\Services\EntryMetadataService;
+use App\Services\ProjectDetectorService;
+use App\Services\QdrantService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Description('Load project-relevant knowledge context. Returns entries grouped by category, ranked by usage and recency. Use at session start for deep project context.')]
+#[IsReadOnly]
+#[IsIdempotent]
+class ContextTool extends Tool
+{
+    private const CHARS_PER_TOKEN = 4;
+
+    private const CATEGORY_ORDER = [
+        'architecture',
+        'patterns',
+        'decisions',
+        'gotchas',
+        'debugging',
+        'testing',
+        'deployment',
+        'security',
+    ];
+
+    public function __construct(
+        private readonly QdrantService $qdrant,
+        private readonly EntryMetadataService $metadata,
+        private readonly ProjectDetectorService $projectDetector,
+    ) {}
+
+    public function handle(Request $request): Response
+    {
+        $project = is_string($request->get('project')) ? $request->get('project') : $this->projectDetector->detect();
+
+        /** @var array<string>|null $categories */
+        $categories = is_array($request->get('categories')) ? $request->get('categories') : null;
+        $maxTokens = is_int($request->get('max_tokens')) ? min($request->get('max_tokens'), 16000) : 4000;
+        $limit = is_int($request->get('limit')) ? min($request->get('limit'), 100) : 50;
+
+        $entries = $this->fetchEntries($categories, $limit, $project);
+
+        if ($entries === []) {
+            $available = $this->qdrant->listCollections();
+            $projects = array_map(
+                fn (string $c): string => str_replace('knowledge_', '', $c),
+                $available
+            );
+
+            return Response::text(json_encode([
+                'project' => $project,
+                'entries' => [],
+                'total' => 0,
+                'message' => "No knowledge entries found for project '{$project}'.",
+                'available_projects' => array_values($projects),
+            ], JSON_THROW_ON_ERROR));
+        }
+
+        $ranked = $this->rankEntries($entries);
+        $grouped = $this->groupByCategory($ranked);
+        $truncated = $this->truncateToTokenBudget($grouped, $maxTokens);
+
+        $totalEntries = array_sum(array_map('count', $truncated));
+
+        return Response::text(json_encode([
+            'project' => $project,
+            'categories' => $truncated,
+            'total' => $totalEntries,
+            'available' => count($entries),
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'project' => $schema->string()
+                ->description('Project namespace. Auto-detected from git if omitted.'),
+            'categories' => $schema->array()
+                ->description('Filter to specific categories (e.g., ["architecture", "debugging"]).'),
+            'max_tokens' => $schema->integer()
+                ->description('Maximum approximate token budget for response (default 4000).')
+                ->default(4000),
+            'limit' => $schema->integer()
+                ->description('Maximum entries to fetch (default 50).')
+                ->default(50),
+        ];
+    }
+
+    /**
+     * @param  array<string>|null  $categories
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchEntries(?array $categories, int $limit, string $project): array
+    {
+        if ($categories !== null && $categories !== []) {
+            $entries = [];
+            $perCategory = max(1, intdiv($limit, count($categories)));
+
+            foreach ($categories as $category) {
+                $results = $this->qdrant->scroll(
+                    ['category' => $category],
+                    $perCategory,
+                    $project
+                );
+
+                foreach ($results->all() as $entry) {
+                    $entries[] = $entry;
+                }
+            }
+
+            return $entries;
+        }
+
+        return $this->qdrant->scroll([], $limit, $project)->all();
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $entries
+     * @return array<int, array<string, mixed>>
+     */
+    private function rankEntries(array $entries): array
+    {
+        $now = time();
+
+        usort($entries, function (array $a, array $b) use ($now): int {
+            $scoreA = $this->entryScore($a, $now);
+            $scoreB = $this->entryScore($b, $now);
+
+            return $scoreB <=> $scoreA;
+        });
+
+        return $entries;
+    }
+
+    /**
+     * @param  array<string, mixed>  $entry
+     */
+    private function entryScore(array $entry, int $now): float
+    {
+        $usageCount = (int) ($entry['usage_count'] ?? 0);
+        $updatedAt = $entry['updated_at'] ?? '';
+        $timestamp = is_string($updatedAt) && $updatedAt !== '' ? strtotime($updatedAt) : $now;
+
+        if ($timestamp === false) {
+            $timestamp = $now;
+        }
+
+        $daysAgo = max(1, (int) (($now - $timestamp) / 86400));
+
+        return ($usageCount * 2.0) + (100.0 / $daysAgo);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $entries
+     * @return array<string, array<int, array<string, mixed>>>
+     */
+    private function groupByCategory(array $entries): array
+    {
+        $grouped = [];
+
+        foreach ($entries as $entry) {
+            $category = is_string($entry['category'] ?? null) && ($entry['category'] ?? '') !== ''
+                ? $entry['category']
+                : 'uncategorized';
+
+            $grouped[$category][] = $this->formatEntry($entry);
+        }
+
+        $ordered = [];
+
+        foreach (self::CATEGORY_ORDER as $cat) {
+            if (isset($grouped[$cat])) {
+                $ordered[$cat] = $grouped[$cat];
+                unset($grouped[$cat]);
+            }
+        }
+
+        ksort($grouped);
+
+        return array_merge($ordered, $grouped);
+    }
+
+    /**
+     * @param  array<string, array<int, array<string, mixed>>>  $grouped
+     * @return array<string, array<int, array<string, mixed>>>
+     */
+    private function truncateToTokenBudget(array $grouped, int $maxTokens): array
+    {
+        $maxChars = $maxTokens * self::CHARS_PER_TOKEN;
+        $charCount = 0;
+        $result = [];
+
+        foreach ($grouped as $category => $entries) {
+            $categoryEntries = [];
+
+            foreach ($entries as $entry) {
+                $entryJson = json_encode($entry, JSON_THROW_ON_ERROR);
+                $entryLen = strlen($entryJson);
+
+                if ($charCount + $entryLen > $maxChars) {
+                    break 2;
+                }
+
+                $categoryEntries[] = $entry;
+                $charCount += $entryLen;
+            }
+
+            if ($categoryEntries !== []) {
+                $result[$category] = $categoryEntries;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  array<string, mixed>  $entry
+     * @return array<string, mixed>
+     */
+    private function formatEntry(array $entry): array
+    {
+        $effectiveConfidence = $this->metadata->calculateEffectiveConfidence($entry);
+
+        return [
+            'id' => $entry['id'],
+            'title' => $entry['title'] ?? '',
+            'content' => $entry['content'] ?? '',
+            'confidence' => $effectiveConfidence,
+            'freshness' => $this->metadata->isStale($entry) ? 'stale' : 'fresh',
+            'priority' => $entry['priority'] ?? 'medium',
+            'tags' => $entry['tags'] ?? [],
+        ];
+    }
+}

--- a/app/Mcp/Tools/CorrectTool.php
+++ b/app/Mcp/Tools/CorrectTool.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools;
+
+use App\Services\CorrectionService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+
+#[Description('Correct wrong knowledge. Supersedes the original entry, creates a corrected version, and propagates corrections to related conflicting entries.')]
+class CorrectTool extends Tool
+{
+    public function __construct(
+        private readonly CorrectionService $correctionService,
+    ) {}
+
+    public function handle(Request $request): Response
+    {
+        $id = $request->get('id');
+        $correctedContent = $request->get('corrected_content');
+
+        if (! is_string($id) || $id === '') {
+            return Response::error('Provide the ID of the entry to correct.');
+        }
+
+        if (! is_string($correctedContent) || strlen($correctedContent) < 10) {
+            return Response::error('Provide corrected content of at least 10 characters.');
+        }
+
+        try {
+            $result = $this->correctionService->correct($id, $correctedContent);
+
+            return Response::text(json_encode([
+                'status' => 'corrected',
+                'corrected_entry_id' => $result['corrected_entry_id'],
+                'original_id' => $id,
+                'superseded_ids' => $result['superseded_ids'],
+                'conflicts_resolved' => $result['conflicts_found'],
+                'message' => "Entry corrected. New entry: {$result['corrected_entry_id']}. "
+                    .count($result['superseded_ids']).' related entries superseded.',
+            ], JSON_THROW_ON_ERROR));
+        } catch (\RuntimeException $e) {
+            return Response::error('Correction failed: '.$e->getMessage());
+        }
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'id' => $schema->string()
+                ->description('ID of the entry to correct (from a previous recall result).')
+                ->required(),
+            'corrected_content' => $schema->string()
+                ->description('The corrected information that replaces the wrong content.')
+                ->required(),
+        ];
+    }
+}

--- a/app/Mcp/Tools/RecallTool.php
+++ b/app/Mcp/Tools/RecallTool.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools;
+
+use App\Services\EntryMetadataService;
+use App\Services\ProjectDetectorService;
+use App\Services\QdrantService;
+use App\Services\TieredSearchService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Description('Search knowledge entries using semantic vector search with tiered retrieval. Returns results ranked by relevance, confidence, and freshness.')]
+#[IsReadOnly]
+#[IsIdempotent]
+class RecallTool extends Tool
+{
+    public function __construct(
+        private readonly TieredSearchService $tieredSearch,
+        private readonly QdrantService $qdrant,
+        private readonly EntryMetadataService $metadata,
+        private readonly ProjectDetectorService $projectDetector,
+    ) {}
+
+    public function handle(Request $request): Response
+    {
+        /** @var string $query */
+        $query = $request->get('query');
+
+        if (! is_string($query) || strlen($query) < 2) {
+            return Response::error('A search query of at least 2 characters is required.');
+        }
+
+        $project = is_string($request->get('project')) ? $request->get('project') : $this->projectDetector->detect();
+        $limit = is_int($request->get('limit')) ? min($request->get('limit'), 20) : 5;
+        $global = (bool) ($request->get('global') ?? false);
+
+        $filters = array_filter([
+            'category' => is_string($request->get('category')) ? $request->get('category') : null,
+            'tag' => is_string($request->get('tag')) ? $request->get('tag') : null,
+        ]);
+
+        if ($global) {
+            return $this->searchGlobal($query, $filters, $limit);
+        }
+
+        $results = $this->tieredSearch->search($query, $filters, $limit, project: $project);
+
+        if ($results->isEmpty()) {
+            return Response::text(json_encode([
+                'results' => [],
+                'meta' => [
+                    'query' => $query,
+                    'project' => $project,
+                    'total' => 0,
+                ],
+            ], JSON_THROW_ON_ERROR));
+        }
+
+        $formatted = $results->map(fn (array $entry): array => $this->formatEntry($entry))->values()->all();
+
+        return Response::text(json_encode([
+            'results' => $formatted,
+            'meta' => [
+                'query' => $query,
+                'project' => $project,
+                'total' => count($formatted),
+                'search_tier' => $results->first()['tier_label'] ?? 'unknown',
+            ],
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'query' => $schema->string()
+                ->description('Natural language search query (e.g., "how do we handle database migrations", "Laravel testing patterns")')
+                ->required(),
+            'project' => $schema->string()
+                ->description('Project namespace. Auto-detected from git if omitted.'),
+            'category' => $schema->string()
+                ->enum(['architecture', 'patterns', 'decisions', 'gotchas', 'debugging', 'testing', 'deployment', 'security'])
+                ->description('Filter results by category.'),
+            'tag' => $schema->string()
+                ->description('Filter results by tag.'),
+            'limit' => $schema->integer()
+                ->description('Maximum results to return (default 5, max 20).')
+                ->default(5),
+            'global' => $schema->boolean()
+                ->description('Search across all projects instead of just the current one.')
+                ->default(false),
+        ];
+    }
+
+    /**
+     * @param  array<string, string>  $filters
+     */
+    private function searchGlobal(string $query, array $filters, int $limit): Response
+    {
+        $collections = $this->qdrant->listCollections();
+        $allResults = [];
+
+        foreach ($collections as $collection) {
+            $projectName = str_replace('knowledge_', '', $collection);
+            $results = $this->tieredSearch->search($query, $filters, $limit, project: $projectName);
+
+            foreach ($results as $entry) {
+                $entry['project'] = $projectName;
+                $allResults[] = $this->formatEntry($entry);
+            }
+        }
+
+        usort($allResults, fn (array $a, array $b): int => $b['relevance_score'] <=> $a['relevance_score']);
+        $allResults = array_slice($allResults, 0, $limit);
+
+        return Response::text(json_encode([
+            'results' => $allResults,
+            'meta' => [
+                'query' => $query,
+                'project' => 'global',
+                'total' => count($allResults),
+                'collections_searched' => count($collections),
+            ],
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @param  array<string, mixed>  $entry
+     * @return array<string, mixed>
+     */
+    private function formatEntry(array $entry): array
+    {
+        $effectiveConfidence = $this->metadata->calculateEffectiveConfidence($entry);
+        $isStale = $this->metadata->isStale($entry);
+
+        return [
+            'id' => $entry['id'],
+            'title' => $entry['title'] ?? '',
+            'content' => $entry['content'] ?? '',
+            'category' => $entry['category'] ?? null,
+            'tags' => $entry['tags'] ?? [],
+            'confidence' => $effectiveConfidence,
+            'freshness' => $isStale ? 'stale' : 'fresh',
+            'relevance_score' => round((float) ($entry['tiered_score'] ?? $entry['score'] ?? 0.0), 3),
+            'project' => $entry['project'] ?? $entry['_project'] ?? null,
+        ];
+    }
+}

--- a/app/Mcp/Tools/RememberTool.php
+++ b/app/Mcp/Tools/RememberTool.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools;
+
+use App\Exceptions\Qdrant\DuplicateEntryException;
+use App\Services\EnhancementQueueService;
+use App\Services\GitContextService;
+use App\Services\ProjectDetectorService;
+use App\Services\QdrantService;
+use App\Services\WriteGateService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Str;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+
+#[Description('Capture a discovery or insight into the knowledge base. Auto-detects git context, validates quality via write gate, and checks for duplicates.')]
+class RememberTool extends Tool
+{
+    public function __construct(
+        private readonly QdrantService $qdrant,
+        private readonly WriteGateService $writeGate,
+        private readonly GitContextService $gitContext,
+        private readonly ProjectDetectorService $projectDetector,
+        private readonly EnhancementQueueService $enhancementQueue,
+    ) {}
+
+    public function handle(Request $request): Response
+    {
+        $title = $request->get('title');
+        $content = $request->get('content');
+
+        if (! is_string($title) || strlen($title) < 5) {
+            return Response::error('A title of at least 5 characters is required.');
+        }
+
+        if (! is_string($content) || strlen($content) < 10) {
+            return Response::error('Content of at least 10 characters is required.');
+        }
+
+        $project = is_string($request->get('project')) ? $request->get('project') : $this->projectDetector->detect();
+
+        /** @var array<string>|null $tags */
+        $tags = is_array($request->get('tags')) ? $request->get('tags') : [];
+
+        $entry = [
+            'id' => Str::uuid()->toString(),
+            'title' => $title,
+            'content' => $content,
+            'category' => is_string($request->get('category')) ? $request->get('category') : null,
+            'tags' => $tags,
+            'priority' => is_string($request->get('priority')) ? $request->get('priority') : 'medium',
+            'confidence' => is_int($request->get('confidence')) ? $request->get('confidence') : 50,
+            'status' => 'draft',
+            'evidence' => is_string($request->get('evidence')) ? $request->get('evidence') : null,
+            'last_verified' => now()->toIso8601String(),
+        ];
+
+        // Auto-populate git context
+        if ($this->gitContext->isGitRepository()) {
+            $context = $this->gitContext->getContext();
+            $entry['repo'] = $context['repo'] ?? null;
+            $entry['branch'] = $context['branch'] ?? null;
+            $entry['commit'] = $context['commit'] ?? null;
+            $entry['author'] = $context['author'] ?? null;
+        }
+
+        // Write gate validation
+        $gateResult = $this->writeGate->evaluate($entry);
+        if (! $gateResult['passed']) {
+            return Response::error('Write gate rejected: '.$gateResult['reason'].'. Improve the entry quality and try again.');
+        }
+
+        // Store with duplicate detection
+        try {
+            $this->qdrant->upsert($entry, $project, true);
+        } catch (DuplicateEntryException $e) {
+            return Response::text(json_encode([
+                'status' => 'duplicate_detected',
+                'existing_id' => $e->existingId,
+                'similarity' => $e->similarityScore !== null ? round($e->similarityScore * 100, 1) : null,
+                'message' => "Similar entry already exists (ID: {$e->existingId}). Use the `correct` tool to update it, or add more distinct content.",
+            ], JSON_THROW_ON_ERROR));
+        }
+
+        // Queue for Ollama auto-tagging
+        if ((bool) config('search.ollama.enabled', true)) {
+            $this->enhancementQueue->queue($entry);
+        }
+
+        return Response::text(json_encode([
+            'status' => 'created',
+            'id' => $entry['id'],
+            'title' => $entry['title'],
+            'project' => $project,
+            'confidence' => $entry['confidence'],
+            'message' => 'Knowledge entry captured successfully.',
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'title' => $schema->string()
+                ->description('Short summary of the knowledge (5-200 chars). e.g., "Pest arch() tests prevent namespace violations"')
+                ->required(),
+            'content' => $schema->string()
+                ->description('Detailed description of the discovery or insight (10-10000 chars).')
+                ->required(),
+            'category' => $schema->string()
+                ->enum(['architecture', 'patterns', 'decisions', 'gotchas', 'debugging', 'testing', 'deployment', 'security'])
+                ->description('Knowledge category. Omit to let auto-tagging classify it.'),
+            'tags' => $schema->array()
+                ->description('Tags for categorization (max 10). e.g., ["laravel", "pest", "testing"]'),
+            'priority' => $schema->string()
+                ->enum(['critical', 'high', 'medium', 'low'])
+                ->description('Priority level.')
+                ->default('medium'),
+            'confidence' => $schema->integer()
+                ->description('How confident you are in this knowledge (0-100). Default 50.')
+                ->default(50),
+            'evidence' => $schema->string()
+                ->description('Supporting evidence or reference URL.'),
+            'project' => $schema->string()
+                ->description('Project namespace. Auto-detected from git if omitted.'),
+        ];
+    }
+}

--- a/app/Mcp/Tools/StatsTool.php
+++ b/app/Mcp/Tools/StatsTool.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools;
+
+use App\Services\ProjectDetectorService;
+use App\Services\QdrantService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Description('Get knowledge base statistics: entry counts, project namespaces, and system health.')]
+#[IsReadOnly]
+#[IsIdempotent]
+class StatsTool extends Tool
+{
+    public function __construct(
+        private readonly QdrantService $qdrant,
+        private readonly ProjectDetectorService $projectDetector,
+    ) {}
+
+    public function handle(Request $request): Response
+    {
+        $project = is_string($request->get('project')) ? $request->get('project') : $this->projectDetector->detect();
+
+        $collections = $this->qdrant->listCollections();
+        $projects = [];
+
+        foreach ($collections as $collection) {
+            $projectName = str_replace('knowledge_', '', $collection);
+            $count = $this->qdrant->count($projectName);
+            $projects[$projectName] = $count;
+        }
+
+        $currentProjectCount = $projects[$project] ?? 0;
+        $totalEntries = array_sum($projects);
+
+        return Response::text(json_encode([
+            'current_project' => $project,
+            'current_project_entries' => $currentProjectCount,
+            'total_entries' => $totalEntries,
+            'projects' => $projects,
+            'project_count' => count($projects),
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'project' => $schema->string()
+                ->description('Project to focus on. Auto-detected from git if omitted.'),
+        ];
+    }
+}

--- a/app/Providers/McpServiceProvider.php
+++ b/app/Providers/McpServiceProvider.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Laravel\Mcp\Console\Commands\StartCommand;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Server\Registrar;
+
+/**
+ * Slim MCP provider for Laravel Zero.
+ *
+ * The default McpServiceProvider requires illuminate/routing (Route facade),
+ * which Laravel Zero doesn't include. This provider registers only what's
+ * needed for Mcp::local() stdio transport.
+ */
+class McpServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(Registrar::class, fn (): Registrar => new Registrar);
+
+        $this->mergeConfigFrom(
+            base_path('vendor/laravel/mcp/config/mcp.php'),
+            'mcp'
+        );
+    }
+
+    public function boot(): void
+    {
+        $this->registerContainerCallbacks();
+        $this->loadRoutes();
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([StartCommand::class]);
+        }
+    }
+
+    private function registerContainerCallbacks(): void
+    {
+        $this->app->resolving(Request::class, function (Request $request, $app): void {
+            if ($app->bound('mcp.request')) {
+                /** @var Request $currentRequest */
+                $currentRequest = $app->make('mcp.request');
+
+                $request->setArguments($currentRequest->all());
+                $request->setSessionId($currentRequest->sessionId());
+                $request->setMeta($currentRequest->meta());
+            }
+        });
+    }
+
+    private function loadRoutes(): void
+    {
+        $path = base_path('routes/ai.php');
+
+        if (file_exists($path)) {
+            require $path;
+        }
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\McpServiceProvider::class,
 ];

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": "^8.2",
         "illuminate/database": "^12.17",
         "laravel-zero/framework": "^12.0.2",
+        "laravel/mcp": "^0.6.0",
         "saloonphp/saloon": "^3.14",
         "symfony/uid": "^8.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2fb8042162e7b54f70de58d01f92ce7c",
+    "content-hash": "81a5724d1efaf7499f2dea856b5b6775",
     "packages": [
         {
             "name": "brick/math",
@@ -226,6 +226,83 @@
             "time": "2025-08-10T19:31:58+00:00"
         },
         {
+            "name": "doctrine/lexer",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^10.5",
+                "psalm/plugin-phpunit": "^0.18.3",
+                "vimeo/psalm": "^5.21"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/lexer/issues",
+                "source": "https://github.com/doctrine/lexer/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-05T11:56:58+00:00"
+        },
+        {
             "name": "dragonmantank/cron-expression",
             "version": "v3.6.0",
             "source": {
@@ -288,6 +365,73 @@
                 }
             ],
             "time": "2025-10-31T18:51:33+00:00"
+        },
+        {
+            "name": "egulias/email-validator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2.0 || ^3.0",
+                "php": ">=8.1",
+                "symfony/polyfill-intl-idn": "^1.26"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.2",
+                "vimeo/psalm": "^5.12"
+            },
+            "suggest": {
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Egulias\\EmailValidator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eduardo Gulias Davis"
+                }
+            ],
+            "description": "A library for validating emails against several RFCs",
+            "homepage": "https://github.com/egulias/EmailValidator",
+            "keywords": [
+                "email",
+                "emailvalidation",
+                "emailvalidator",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/egulias/EmailValidator/issues",
+                "source": "https://github.com/egulias/EmailValidator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/egulias",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-06T22:45:56+00:00"
         },
         {
             "name": "filp/whoops",
@@ -359,6 +503,77 @@
                 }
             ],
             "time": "2025-08-08T12:00:00+00:00"
+        },
+        {
+            "name": "fruitcake/php-cors",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fruitcake/php-cors.git",
+                "reference": "38aaa6c3fd4c157ffe2a4d10aa8b9b16ba8de379"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fruitcake/php-cors/zipball/38aaa6c3fd4c157ffe2a4d10aa8b9b16ba8de379",
+                "reference": "38aaa6c3fd4c157ffe2a4d10aa8b9b16ba8de379",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "symfony/http-foundation": "^5.4|^6.4|^7.3|^8"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^2",
+                "phpunit/phpunit": "^9",
+                "squizlabs/php_codesniffer": "^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fruitcake\\Cors\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fruitcake",
+                    "homepage": "https://fruitcake.nl"
+                },
+                {
+                    "name": "Barryvdh",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Cross-origin resource sharing library for the Symfony HttpFoundation",
+            "homepage": "https://github.com/fruitcake/php-cors",
+            "keywords": [
+                "cors",
+                "laravel",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/fruitcake/php-cors/issues",
+                "source": "https://github.com/fruitcake/php-cors/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-03T09:33:47+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -746,6 +961,92 @@
                 }
             ],
             "time": "2025-08-23T21:21:41+00:00"
+        },
+        {
+            "name": "guzzlehttp/uri-template",
+            "version": "v1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/uri-template.git",
+                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/4f4bbd4e7172148801e76e3decc1e559bdee34e1",
+                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-php80": "^1.24"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25",
+                "uri-template/tests": "1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\UriTemplate\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                }
+            ],
+            "description": "A polyfill class for uri_template of PHP",
+            "keywords": [
+                "guzzlehttp",
+                "uri-template"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/uri-template/issues",
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/uri-template",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-22T14:27:06+00:00"
         },
         {
             "name": "illuminate/bus",
@@ -1387,6 +1688,115 @@
             "time": "2026-01-19T15:15:34+00:00"
         },
         {
+            "name": "illuminate/http",
+            "version": "v12.53.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/http.git",
+                "reference": "b6351a4b8d3b6b1aef4b08cb98892045b20aa0ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/http/zipball/b6351a4b8d3b6b1aef4b08cb98892045b20aa0ad",
+                "reference": "b6351a4b8d3b6b1aef4b08cb98892045b20aa0ad",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "fruitcake/php-cors": "^1.3",
+                "guzzlehttp/guzzle": "^7.8.2",
+                "guzzlehttp/uri-template": "^1.0",
+                "illuminate/collections": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "illuminate/session": "^12.0",
+                "illuminate/support": "^12.0",
+                "php": "^8.2",
+                "symfony/http-foundation": "^7.2.0",
+                "symfony/http-kernel": "^7.2.0",
+                "symfony/mime": "^7.2.0",
+                "symfony/polyfill-php83": "^1.33",
+                "symfony/polyfill-php85": "^1.33"
+            },
+            "suggest": {
+                "ext-gd": "Required to use Illuminate\\Http\\Testing\\FileFactory::image()."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Http\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Http package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-02-23T15:41:33+00:00"
+        },
+        {
+            "name": "illuminate/json-schema",
+            "version": "v12.53.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/json-schema.git",
+                "reference": "207509531ee53b2c5b966c51c9c63355f8e96e1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/json-schema/zipball/207509531ee53b2c5b966c51c9c63355f8e96e1e",
+                "reference": "207509531ee53b2c5b966c51c9c63355f8e96e1e",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^10.50.0|^11.47.0|^12.40.2",
+                "php": "^8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\JsonSchema\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Json Schema package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-02-24T14:03:17+00:00"
+        },
+        {
             "name": "illuminate/macroable",
             "version": "v12.49.0",
             "source": {
@@ -1587,6 +1997,129 @@
             "time": "2025-12-09T15:11:22+00:00"
         },
         {
+            "name": "illuminate/routing",
+            "version": "v12.53.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/routing.git",
+                "reference": "e20c98c90bc005a3785f630802c29dab8c6631b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/routing/zipball/e20c98c90bc005a3785f630802c29dab8c6631b1",
+                "reference": "e20c98c90bc005a3785f630802c29dab8c6631b1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "illuminate/collections": "^12.0",
+                "illuminate/container": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/http": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "illuminate/pipeline": "^12.0",
+                "illuminate/session": "^12.0",
+                "illuminate/support": "^12.0",
+                "php": "^8.2",
+                "symfony/http-foundation": "^7.2.0",
+                "symfony/http-kernel": "^7.2.0",
+                "symfony/polyfill-php84": "^1.33",
+                "symfony/polyfill-php85": "^1.33",
+                "symfony/routing": "^7.2.0"
+            },
+            "suggest": {
+                "illuminate/console": "Required to use the make commands (^12.0).",
+                "php-http/discovery": "Required to use PSR-7 bridging features (^1.15).",
+                "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.2)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Routing\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Routing package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-02-12T20:05:46+00:00"
+        },
+        {
+            "name": "illuminate/session",
+            "version": "v12.53.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/session.git",
+                "reference": "98802e67dd5e059c0b978b3fe8f5f0a3ac17ec4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/session/zipball/98802e67dd5e059c0b978b3fe8f5f0a3ac17ec4e",
+                "reference": "98802e67dd5e059c0b978b3fe8f5f0a3ac17ec4e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-session": "*",
+                "illuminate/collections": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/filesystem": "^12.0",
+                "illuminate/support": "^12.0",
+                "php": "^8.2",
+                "symfony/finder": "^7.2.0",
+                "symfony/http-foundation": "^7.2.0"
+            },
+            "suggest": {
+                "illuminate/console": "Required to use the session:table command (^12.0)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Session\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Session package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-02-14T23:03:41+00:00"
+        },
+        {
             "name": "illuminate/support",
             "version": "v12.49.0",
             "source": {
@@ -1725,6 +2258,120 @@
                 "source": "https://github.com/laravel/framework"
             },
             "time": "2026-01-20T17:18:54+00:00"
+        },
+        {
+            "name": "illuminate/translation",
+            "version": "v12.53.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/translation.git",
+                "reference": "18aa24aba6f2ab2447b9b903ae7360725fe5bdd0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/translation/zipball/18aa24aba6f2ab2447b9b903ae7360725fe5bdd0",
+                "reference": "18aa24aba6f2ab2447b9b903ae7360725fe5bdd0",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/collections": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/filesystem": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "illuminate/support": "^12.0",
+                "php": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Translation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Translation package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-02-06T12:12:31+00:00"
+        },
+        {
+            "name": "illuminate/validation",
+            "version": "v12.53.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/validation.git",
+                "reference": "bfd544135cb4784c8664a0b5de7cf16830768e8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/validation/zipball/bfd544135cb4784c8664a0b5de7cf16830768e8b",
+                "reference": "bfd544135cb4784c8664a0b5de7cf16830768e8b",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.11|^0.12|^0.13|^0.14",
+                "egulias/email-validator": "^3.2.5|^4.0",
+                "ext-filter": "*",
+                "ext-mbstring": "*",
+                "illuminate/collections": "^12.0",
+                "illuminate/container": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "illuminate/support": "^12.0",
+                "illuminate/translation": "^12.0",
+                "php": "^8.2",
+                "symfony/http-foundation": "^7.2",
+                "symfony/mime": "^7.2",
+                "symfony/polyfill-php83": "^1.33"
+            },
+            "suggest": {
+                "illuminate/database": "Required to use the database presence verifier (^12.0).",
+                "ramsey/uuid": "Required to use Validator::validateUuid() (^4.7)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Validation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Validation package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-02-20T15:20:18+00:00"
         },
         {
             "name": "illuminate/view",
@@ -2070,6 +2717,79 @@
                 }
             ],
             "time": "2026-01-24T09:18:21+00:00"
+        },
+        {
+            "name": "laravel/mcp",
+            "version": "v0.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/mcp.git",
+                "reference": "28860a10ca0cc5433e25d897ba7af844e6c7b6a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/28860a10ca0cc5433e25d897ba7af844e6c7b6a2",
+                "reference": "28860a10ca0cc5433e25d897ba7af844e6c7b6a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "illuminate/console": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/container": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/http": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/json-schema": "^12.41.1|^13.0",
+                "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/support": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/validation": "^11.45.3|^12.41.1|^13.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.20",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "pestphp/pest": "^3.8.5|^4.3.2",
+                "phpstan/phpstan": "^2.1.27",
+                "rector/rector": "^2.2.4"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Mcp": "Laravel\\Mcp\\Server\\Facades\\Mcp"
+                    },
+                    "providers": [
+                        "Laravel\\Mcp\\Server\\McpServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Mcp\\": "src/",
+                    "Laravel\\Mcp\\Server\\": "src/Server/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Rapidly build MCP servers for your Laravel applications.",
+            "homepage": "https://github.com/laravel/mcp",
+            "keywords": [
+                "laravel",
+                "mcp"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/mcp/issues",
+                "source": "https://github.com/laravel/mcp"
+            },
+            "time": "2026-02-24T08:43:06+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -4184,6 +4904,296 @@
             "time": "2026-01-26T15:07:59+00:00"
         },
         {
+            "name": "symfony/http-foundation",
+            "version": "v7.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "fd97d5e926e988a363cef56fbbf88c5c528e9065"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/fd97d5e926e988a363cef56fbbf88c5c528e9065",
+                "reference": "fd97d5e926e988a363cef56fbbf88c5c528e9065",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "^1.1"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6",
+                "symfony/cache": "<6.4.12|>=7.0,<7.1.5"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^3.6|^4",
+                "predis/predis": "^1.1|^2.0",
+                "symfony/cache": "^6.4.12|^7.1.5|^8.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Defines an object-oriented layer for the HTTP specification",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-21T16:25:55+00:00"
+        },
+        {
+            "name": "symfony/http-kernel",
+            "version": "v7.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-kernel.git",
+                "reference": "002ac0cf4cd972a7fd0912dcd513a95e8a81ce83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/002ac0cf4cd972a7fd0912dcd513a95e8a81ce83",
+                "reference": "002ac0cf4cd972a7fd0912dcd513a95e8a81ce83",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/error-handler": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^7.3|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/browser-kit": "<6.4",
+                "symfony/cache": "<6.4",
+                "symfony/config": "<6.4",
+                "symfony/console": "<6.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/doctrine-bridge": "<6.4",
+                "symfony/flex": "<2.10",
+                "symfony/form": "<6.4",
+                "symfony/http-client": "<6.4",
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/mailer": "<6.4",
+                "symfony/messenger": "<6.4",
+                "symfony/translation": "<6.4",
+                "symfony/translation-contracts": "<2.5",
+                "symfony/twig-bridge": "<6.4",
+                "symfony/validator": "<6.4",
+                "symfony/var-dumper": "<6.4",
+                "twig/twig": "<3.12"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "symfony/browser-kit": "^6.4|^7.0|^8.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/css-selector": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4.1|^7.0.1|^8.0",
+                "symfony/dom-crawler": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/http-client-contracts": "^2.5|^3",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^7.1|^8.0",
+                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^7.1|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/translation": "^6.4|^7.0|^8.0",
+                "symfony/translation-contracts": "^2.5|^3",
+                "symfony/uid": "^6.4|^7.0|^8.0",
+                "symfony/validator": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symfony/var-exporter": "^6.4|^7.0|^8.0",
+                "twig/twig": "^3.12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpKernel\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a structured process for converting a Request into a Response",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-26T08:30:57+00:00"
+        },
+        {
+            "name": "symfony/mime",
+            "version": "v7.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "9fc881d95feae4c6c48678cb6372bd8a7ba04f5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/9fc881d95feae4c6c48678cb6372bd8a7ba04f5f",
+                "reference": "9fc881d95feae4c6c48678cb6372bd8a7ba04f5f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "egulias/email-validator": "~3.0.0",
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/mailer": "<6.4",
+                "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3.1|^4",
+                "league/html-to-markdown": "^5.0",
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4.3|^7.0.3|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows manipulating MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/mime/tree/v7.4.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-05T15:57:06+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.33.0",
             "source": {
@@ -4347,6 +5357,93 @@
                 }
             ],
             "time": "2025-06-27T09:58:17+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "symfony/polyfill-intl-normalizer": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-10T14:38:51+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
@@ -4989,6 +6086,91 @@
                 }
             ],
             "time": "2026-01-26T15:07:59+00:00"
+        },
+        {
+            "name": "symfony/routing",
+            "version": "v7.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/routing.git",
+                "reference": "238d749c56b804b31a9bf3e26519d93b65a60938"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/238d749c56b804b31a9bf3e26519d93b65a60938",
+                "reference": "238d749c56b804b31a9bf3e26519d93b65a60938",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/config": "<6.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/yaml": "<6.4"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Routing\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Maps an HTTP request to a set of configuration variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "router",
+                "routing",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/routing/tree/v7.4.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-25T16:50:00+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Mcp\Servers\KnowledgeServer;
+use Laravel\Mcp\Facades\Mcp;
+
+Mcp::local('knowledge', KnowledgeServer::class);

--- a/tests/Unit/Mcp/Tools/ContextToolTest.php
+++ b/tests/Unit/Mcp/Tools/ContextToolTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Mcp\Tools\ContextTool;
+use App\Services\EntryMetadataService;
+use App\Services\ProjectDetectorService;
+use App\Services\QdrantService;
+use Laravel\Mcp\Request;
+
+uses()->group('mcp-tools');
+
+beforeEach(function (): void {
+    $this->qdrant = Mockery::mock(QdrantService::class);
+    $this->metadata = Mockery::mock(EntryMetadataService::class);
+    $this->projectDetector = Mockery::mock(ProjectDetectorService::class);
+
+    $this->tool = new ContextTool(
+        $this->qdrant,
+        $this->metadata,
+        $this->projectDetector,
+    );
+});
+
+describe('context tool', function (): void {
+    it('returns empty results with available projects when no entries found', function (): void {
+        $this->projectDetector->shouldReceive('detect')->once()->andReturn('empty-project');
+        $this->qdrant->shouldReceive('scroll')
+            ->once()
+            ->andReturn(collect());
+        $this->qdrant->shouldReceive('listCollections')
+            ->once()
+            ->andReturn(['knowledge_default', 'knowledge_odin']);
+
+        $request = new Request([]);
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeFalse();
+
+        $data = json_decode((string) $response->content(), true);
+        expect($data['total'])->toBe(0)
+            ->and($data['project'])->toBe('empty-project')
+            ->and($data['available_projects'])->toContain('default', 'odin');
+    });
+
+    it('returns grouped and ranked entries', function (): void {
+        $this->projectDetector->shouldReceive('detect')->once()->andReturn('test-project');
+        $this->qdrant->shouldReceive('scroll')
+            ->once()
+            ->andReturn(collect([
+                [
+                    'id' => 'entry-1',
+                    'title' => 'Architecture Pattern',
+                    'content' => 'Use hexagonal architecture.',
+                    'category' => 'architecture',
+                    'tags' => ['patterns'],
+                    'priority' => 'high',
+                    'usage_count' => 5,
+                    'updated_at' => now()->toIso8601String(),
+                    'confidence' => 80,
+                ],
+                [
+                    'id' => 'entry-2',
+                    'title' => 'Debug Tip',
+                    'content' => 'Check logs first.',
+                    'category' => 'debugging',
+                    'tags' => [],
+                    'priority' => 'medium',
+                    'usage_count' => 2,
+                    'updated_at' => now()->subDays(30)->toIso8601String(),
+                    'confidence' => 60,
+                ],
+            ]));
+
+        $this->metadata->shouldReceive('calculateEffectiveConfidence')->twice()->andReturn(75, 55);
+        $this->metadata->shouldReceive('isStale')->twice()->andReturn(false, true);
+
+        $request = new Request([]);
+        $response = $this->tool->handle($request);
+
+        $data = json_decode((string) $response->content(), true);
+        expect($data['total'])->toBe(2)
+            ->and($data['categories'])->toHaveKey('architecture')
+            ->and($data['categories'])->toHaveKey('debugging');
+    });
+
+    it('filters by specific categories', function (): void {
+        $this->projectDetector->shouldReceive('detect')->once()->andReturn('test-project');
+        $this->qdrant->shouldReceive('scroll')
+            ->with(['category' => 'architecture'], Mockery::any(), 'test-project')
+            ->once()
+            ->andReturn(collect([
+                [
+                    'id' => 'entry-1',
+                    'title' => 'Arch Pattern',
+                    'content' => 'Content here.',
+                    'category' => 'architecture',
+                    'tags' => [],
+                    'priority' => 'high',
+                    'usage_count' => 1,
+                    'updated_at' => now()->toIso8601String(),
+                    'confidence' => 80,
+                ],
+            ]));
+
+        $this->metadata->shouldReceive('calculateEffectiveConfidence')->once()->andReturn(80);
+        $this->metadata->shouldReceive('isStale')->once()->andReturn(false);
+
+        $request = new Request(['categories' => ['architecture']]);
+        $response = $this->tool->handle($request);
+
+        $data = json_decode((string) $response->content(), true);
+        expect($data['total'])->toBe(1);
+    });
+
+    it('uses explicit project parameter', function (): void {
+        $this->projectDetector->shouldNotReceive('detect');
+        $this->qdrant->shouldReceive('scroll')
+            ->withArgs(fn ($f, $l, $project) => $project === 'odin')
+            ->once()
+            ->andReturn(collect());
+        $this->qdrant->shouldReceive('listCollections')->once()->andReturn([]);
+
+        $request = new Request(['project' => 'odin']);
+        $this->tool->handle($request);
+    });
+});

--- a/tests/Unit/Mcp/Tools/CorrectToolTest.php
+++ b/tests/Unit/Mcp/Tools/CorrectToolTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Mcp\Tools\CorrectTool;
+use App\Services\CorrectionService;
+use Laravel\Mcp\Request;
+
+uses()->group('mcp-tools');
+
+beforeEach(function (): void {
+    $this->correctionService = Mockery::mock(CorrectionService::class);
+    $this->tool = new CorrectTool($this->correctionService);
+});
+
+describe('correct tool', function (): void {
+    it('returns error when id is missing', function (): void {
+        $request = new Request(['corrected_content' => 'New corrected content here.']);
+
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeTrue();
+    });
+
+    it('returns error when corrected content is missing', function (): void {
+        $request = new Request(['id' => 'entry-123']);
+
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeTrue();
+    });
+
+    it('returns error when corrected content is too short', function (): void {
+        $request = new Request(['id' => 'entry-123', 'corrected_content' => 'Short']);
+
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeTrue();
+    });
+
+    it('corrects entry and returns result', function (): void {
+        $this->correctionService->shouldReceive('correct')
+            ->with('entry-123', 'This is the corrected information that replaces the original.')
+            ->once()
+            ->andReturn([
+                'corrected_entry_id' => 'new-entry-456',
+                'superseded_ids' => ['entry-789'],
+                'conflicts_found' => 1,
+            ]);
+
+        $request = new Request([
+            'id' => 'entry-123',
+            'corrected_content' => 'This is the corrected information that replaces the original.',
+        ]);
+
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeFalse();
+
+        $data = json_decode((string) $response->content(), true);
+        expect($data['status'])->toBe('corrected')
+            ->and($data['corrected_entry_id'])->toBe('new-entry-456')
+            ->and($data['original_id'])->toBe('entry-123')
+            ->and($data['conflicts_resolved'])->toBe(1);
+    });
+
+    it('handles correction service failures', function (): void {
+        $this->correctionService->shouldReceive('correct')
+            ->once()
+            ->andThrow(new RuntimeException('Entry not found'));
+
+        $request = new Request([
+            'id' => 'nonexistent-id',
+            'corrected_content' => 'Corrected content that will fail to apply.',
+        ]);
+
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeTrue();
+    });
+});

--- a/tests/Unit/Mcp/Tools/RecallToolTest.php
+++ b/tests/Unit/Mcp/Tools/RecallToolTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Mcp\Tools\RecallTool;
+use App\Services\EntryMetadataService;
+use App\Services\ProjectDetectorService;
+use App\Services\QdrantService;
+use App\Services\TieredSearchService;
+use Laravel\Mcp\Request;
+
+uses()->group('mcp-tools');
+
+beforeEach(function (): void {
+    $this->tieredSearch = Mockery::mock(TieredSearchService::class);
+    $this->qdrant = Mockery::mock(QdrantService::class);
+    $this->metadata = Mockery::mock(EntryMetadataService::class);
+    $this->projectDetector = Mockery::mock(ProjectDetectorService::class);
+
+    $this->tool = new RecallTool(
+        $this->tieredSearch,
+        $this->qdrant,
+        $this->metadata,
+        $this->projectDetector,
+    );
+});
+
+describe('recall tool', function (): void {
+    it('returns error when query is missing', function (): void {
+        $request = new Request([]);
+
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeTrue();
+    });
+
+    it('returns error when query is too short', function (): void {
+        $request = new Request(['query' => 'a']);
+
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeTrue();
+    });
+
+    it('returns empty results when nothing found', function (): void {
+        $this->projectDetector->shouldReceive('detect')->once()->andReturn('test-project');
+        $this->tieredSearch->shouldReceive('search')
+            ->once()
+            ->andReturn(collect());
+
+        $request = new Request(['query' => 'test query']);
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeFalse();
+
+        $data = json_decode((string) $response->content(), true);
+        expect($data['results'])->toBeEmpty()
+            ->and($data['meta']['total'])->toBe(0)
+            ->and($data['meta']['project'])->toBe('test-project');
+    });
+
+    it('returns formatted results with confidence and freshness', function (): void {
+        $this->projectDetector->shouldReceive('detect')->once()->andReturn('test-project');
+        $this->tieredSearch->shouldReceive('search')
+            ->once()
+            ->andReturn(collect([
+                [
+                    'id' => 'entry-1',
+                    'title' => 'Test Entry',
+                    'content' => 'Some content',
+                    'category' => 'architecture',
+                    'tags' => ['laravel'],
+                    'tiered_score' => 0.95,
+                    'tier_label' => 'exact',
+                    'confidence' => 80,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+            ]));
+
+        $this->metadata->shouldReceive('calculateEffectiveConfidence')->once()->andReturn(75);
+        $this->metadata->shouldReceive('isStale')->once()->andReturn(false);
+
+        $request = new Request(['query' => 'test query']);
+        $response = $this->tool->handle($request);
+
+        $data = json_decode((string) $response->content(), true);
+        expect($data['results'])->toHaveCount(1)
+            ->and($data['results'][0]['id'])->toBe('entry-1')
+            ->and($data['results'][0]['confidence'])->toBe(75)
+            ->and($data['results'][0]['freshness'])->toBe('fresh')
+            ->and($data['meta']['total'])->toBe(1);
+    });
+
+    it('uses explicit project when provided', function (): void {
+        $this->projectDetector->shouldNotReceive('detect');
+        $this->tieredSearch->shouldReceive('search')
+            ->withArgs(fn ($q, $f, $l, $forceTier, $p) => $p === 'my-project')
+            ->once()
+            ->andReturn(collect());
+
+        $request = new Request(['query' => 'test', 'project' => 'my-project']);
+        $this->tool->handle($request);
+    });
+
+    it('searches globally across all collections', function (): void {
+        $this->projectDetector->shouldReceive('detect')->once()->andReturn('default');
+        $this->qdrant->shouldReceive('listCollections')
+            ->once()
+            ->andReturn(['knowledge_project_a', 'knowledge_project_b']);
+
+        $this->tieredSearch->shouldReceive('search')
+            ->twice()
+            ->andReturn(collect());
+
+        $request = new Request(['query' => 'test', 'global' => true]);
+        $response = $this->tool->handle($request);
+
+        $data = json_decode((string) $response->content(), true);
+        expect($data['meta']['collections_searched'])->toBe(2);
+    });
+
+    it('respects limit parameter', function (): void {
+        $this->projectDetector->shouldReceive('detect')->once()->andReturn('default');
+        $this->tieredSearch->shouldReceive('search')
+            ->withArgs(fn ($q, $f, $limit) => $limit === 10)
+            ->once()
+            ->andReturn(collect());
+
+        $request = new Request(['query' => 'test', 'limit' => 10]);
+        $this->tool->handle($request);
+    });
+});

--- a/tests/Unit/Mcp/Tools/RememberToolTest.php
+++ b/tests/Unit/Mcp/Tools/RememberToolTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Exceptions\Qdrant\DuplicateEntryException;
+use App\Mcp\Tools\RememberTool;
+use App\Services\EnhancementQueueService;
+use App\Services\GitContextService;
+use App\Services\ProjectDetectorService;
+use App\Services\QdrantService;
+use App\Services\WriteGateService;
+use Laravel\Mcp\Request;
+
+uses()->group('mcp-tools');
+
+beforeEach(function (): void {
+    $this->qdrant = Mockery::mock(QdrantService::class);
+    $this->writeGate = Mockery::mock(WriteGateService::class);
+    $this->gitContext = Mockery::mock(GitContextService::class);
+    $this->projectDetector = Mockery::mock(ProjectDetectorService::class);
+    $this->enhancementQueue = Mockery::mock(EnhancementQueueService::class);
+
+    $this->tool = new RememberTool(
+        $this->qdrant,
+        $this->writeGate,
+        $this->gitContext,
+        $this->projectDetector,
+        $this->enhancementQueue,
+    );
+});
+
+describe('remember tool', function (): void {
+    it('returns error when title is missing', function (): void {
+        $request = new Request(['content' => 'Some long content here']);
+
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeTrue();
+    });
+
+    it('returns error when title is too short', function (): void {
+        $request = new Request(['title' => 'Hi', 'content' => 'Some long content here']);
+
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeTrue();
+    });
+
+    it('returns error when content is missing', function (): void {
+        $request = new Request(['title' => 'Valid Title']);
+
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeTrue();
+    });
+
+    it('returns error when content is too short', function (): void {
+        $request = new Request(['title' => 'Valid Title', 'content' => 'Short']);
+
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeTrue();
+    });
+
+    it('creates entry successfully with git context', function (): void {
+        $this->projectDetector->shouldReceive('detect')->once()->andReturn('test-project');
+        $this->gitContext->shouldReceive('isGitRepository')->once()->andReturn(true);
+        $this->gitContext->shouldReceive('getContext')->once()->andReturn([
+            'repo' => 'knowledge',
+            'branch' => 'main',
+            'commit' => 'abc123',
+            'author' => 'test',
+        ]);
+        $this->writeGate->shouldReceive('evaluate')->once()->andReturn(['passed' => true]);
+        $this->qdrant->shouldReceive('upsert')->once()->andReturn(true);
+        $this->enhancementQueue->shouldReceive('queue')->once();
+
+        config(['search.ollama.enabled' => true]);
+
+        $request = new Request([
+            'title' => 'Test Discovery',
+            'content' => 'This is an important discovery about the system.',
+        ]);
+
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeFalse();
+
+        $data = json_decode((string) $response->content(), true);
+        expect($data['status'])->toBe('created')
+            ->and($data['project'])->toBe('test-project');
+    });
+
+    it('returns write gate rejection', function (): void {
+        $this->projectDetector->shouldReceive('detect')->once()->andReturn('default');
+        $this->gitContext->shouldReceive('isGitRepository')->once()->andReturn(false);
+        $this->writeGate->shouldReceive('evaluate')->once()->andReturn([
+            'passed' => false,
+            'reason' => 'Content too generic',
+        ]);
+
+        $request = new Request([
+            'title' => 'Generic Title Here',
+            'content' => 'This is some generic content for testing.',
+        ]);
+
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeTrue();
+    });
+
+    it('handles duplicate detection gracefully', function (): void {
+        $this->projectDetector->shouldReceive('detect')->once()->andReturn('default');
+        $this->gitContext->shouldReceive('isGitRepository')->once()->andReturn(false);
+        $this->writeGate->shouldReceive('evaluate')->once()->andReturn(['passed' => true]);
+        $this->qdrant->shouldReceive('upsert')->once()->andThrow(
+            DuplicateEntryException::similarityMatch('existing-id', 0.98)
+        );
+
+        $request = new Request([
+            'title' => 'Duplicate Entry',
+            'content' => 'This content already exists in the knowledge base.',
+        ]);
+
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeFalse();
+
+        $data = json_decode((string) $response->content(), true);
+        expect($data['status'])->toBe('duplicate_detected')
+            ->and($data['existing_id'])->toBe('existing-id');
+    });
+
+    it('uses explicit project when provided', function (): void {
+        $this->projectDetector->shouldNotReceive('detect');
+        $this->gitContext->shouldReceive('isGitRepository')->once()->andReturn(false);
+        $this->writeGate->shouldReceive('evaluate')->once()->andReturn(['passed' => true]);
+        $this->qdrant->shouldReceive('upsert')
+            ->withArgs(fn ($entry, $project) => $project === 'custom-project')
+            ->once()
+            ->andReturn(true);
+        $this->enhancementQueue->shouldReceive('queue')->once();
+
+        config(['search.ollama.enabled' => true]);
+
+        $request = new Request([
+            'title' => 'Project Specific',
+            'content' => 'This belongs to a specific project namespace.',
+            'project' => 'custom-project',
+        ]);
+
+        $response = $this->tool->handle($request);
+
+        $data = json_decode((string) $response->content(), true);
+        expect($data['project'])->toBe('custom-project');
+    });
+});

--- a/tests/Unit/Mcp/Tools/StatsToolTest.php
+++ b/tests/Unit/Mcp/Tools/StatsToolTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Mcp\Tools\StatsTool;
+use App\Services\ProjectDetectorService;
+use App\Services\QdrantService;
+use Laravel\Mcp\Request;
+
+uses()->group('mcp-tools');
+
+beforeEach(function (): void {
+    $this->qdrant = Mockery::mock(QdrantService::class);
+    $this->projectDetector = Mockery::mock(ProjectDetectorService::class);
+
+    $this->tool = new StatsTool($this->qdrant, $this->projectDetector);
+});
+
+describe('stats tool', function (): void {
+    it('returns stats across all projects', function (): void {
+        $this->projectDetector->shouldReceive('detect')->once()->andReturn('knowledge');
+        $this->qdrant->shouldReceive('listCollections')
+            ->once()
+            ->andReturn(['knowledge_default', 'knowledge_odin', 'knowledge_knowledge']);
+        $this->qdrant->shouldReceive('count')
+            ->with('default')
+            ->once()
+            ->andReturn(4549);
+        $this->qdrant->shouldReceive('count')
+            ->with('odin')
+            ->once()
+            ->andReturn(3);
+        $this->qdrant->shouldReceive('count')
+            ->with('knowledge')
+            ->once()
+            ->andReturn(18);
+
+        $request = new Request([]);
+        $response = $this->tool->handle($request);
+
+        expect($response->isError())->toBeFalse();
+
+        $data = json_decode((string) $response->content(), true);
+        expect($data['current_project'])->toBe('knowledge')
+            ->and($data['current_project_entries'])->toBe(18)
+            ->and($data['total_entries'])->toBe(4570)
+            ->and($data['project_count'])->toBe(3)
+            ->and($data['projects']['default'])->toBe(4549);
+    });
+
+    it('uses explicit project parameter', function (): void {
+        $this->projectDetector->shouldNotReceive('detect');
+        $this->qdrant->shouldReceive('listCollections')->once()->andReturn(['knowledge_odin']);
+        $this->qdrant->shouldReceive('count')->with('odin')->once()->andReturn(3);
+
+        $request = new Request(['project' => 'odin']);
+        $response = $this->tool->handle($request);
+
+        $data = json_decode((string) $response->content(), true);
+        expect($data['current_project'])->toBe('odin')
+            ->and($data['current_project_entries'])->toBe(3);
+    });
+});


### PR DESCRIPTION
## Summary
- Replaces the fragile Node.js `knowledge-server.js` wrapper with native `laravel/mcp` v0.6.0 integration
- 5 intent-based MCP tools: `recall`, `remember`, `correct`, `context`, `stats`
- Custom `McpServiceProvider` for Laravel Zero compatibility (no routing/validation deps)
- Stdio transport via `Mcp::local()` for Claude Code and Claude Desktop

## Bugs fixed from initial testing
- `RememberTool` referenced undefined `$validated['evidence']` — now uses `$request->get('evidence')`
- Category enums aligned across all tools (added `patterns`, `decisions`, `gotchas`)
- `ContextTool` empty results now show `available_projects` list to help users find the right namespace

## Claude Desktop config
```json
{
  "knowledge": {
    "command": "php",
    "args": ["/path/to/knowledge/know", "mcp:start", "knowledge"]
  }
}
```

## Test plan
- [x] MCP initialize handshake returns correct server info
- [x] `tools/list` returns all 5 tools with schemas
- [x] `recall` returns ranked results with confidence/freshness
- [x] `stats` returns entry counts across all projects
- [x] `remember` captures entries with git context and dedup
- [x] 571 unit tests pass, 0 failures
- [ ] Sentinel Gate CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched a semantic knowledge base with commands to recall, remember, correct, view context, and see stats.
  * Project-aware knowledge organization with category/tag filtering, auto-detection of project context, and git context capture.
  * Intelligent retrieval: ranking by confidence and freshness, grouped context constrained to token budgets.
  * Recall supports global and per-project search; Remember includes duplicate detection and optional auto-tagging.
  * Added a stats endpoint reporting per-project and total entry counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->