### PR TITLE
fix: normalize JSON-encoded tags in payload hydration

### DIFF
--- a/app/Services/QdrantService.php
+++ b/app/Services/QdrantService.php
@@ -787,7 +787,7 @@ class QdrantService
             'score' => $result['score'] ?? 0.0,
             'title' => $payload['title'] ?? '',
             'content' => $payload['content'] ?? '',
-            'tags' => $payload['tags'] ?? [],
+            'tags' => $this->normalizeTags($payload['tags'] ?? []),
             'category' => $payload['category'] ?? null,
             'module' => $payload['module'] ?? null,
             'priority' => $payload['priority'] ?? null,
@@ -818,7 +818,7 @@ class QdrantService
             'id' => $point['id'],
             'title' => $payload['title'] ?? '',
             'content' => $payload['content'] ?? '',
-            'tags' => $payload['tags'] ?? [],
+            'tags' => $this->normalizeTags($payload['tags'] ?? []),
             'category' => $payload['category'] ?? null,
             'module' => $payload['module'] ?? null,
             'priority' => $payload['priority'] ?? null,
@@ -973,6 +973,27 @@ class QdrantService
     /**
      * Get collection name for project namespace.
      */
+    /**
+     * Normalize tags from Qdrant payload — handles JSON-encoded strings.
+     *
+     * @return array<string>
+     */
+    private function normalizeTags(mixed $tags): array
+    {
+        if (is_array($tags)) {
+            return $tags;
+        }
+
+        if (is_string($tags) && str_starts_with($tags, '[')) {
+            $decoded = json_decode($tags, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return [];
+    }
+
     public function getCollectionName(string $project): string
     {
         return 'knowledge_'.str_replace(['/', '\\', ' '], '_', $project);

--- a/tests/Unit/Services/QdrantServiceTest.php
+++ b/tests/Unit/Services/QdrantServiceTest.php
@@ -1784,3 +1784,32 @@ describe('searchRawCollection', function (): void {
         expect($results)->toBeEmpty();
     });
 });
+
+describe('normalizeTags', function (): void {
+    it('passes through normal arrays', function (): void {
+        $method = new ReflectionMethod($this->service, 'normalizeTags');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->service, ['rock', 'punk']);
+
+        expect($result)->toBe(['rock', 'punk']);
+    });
+
+    it('decodes JSON-encoded string arrays', function (): void {
+        $method = new ReflectionMethod($this->service, 'normalizeTags');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->service, '["rock","punk","metal"]');
+
+        expect($result)->toBe(['rock', 'punk', 'metal']);
+    });
+
+    it('returns empty array for non-array non-JSON strings', function (): void {
+        $method = new ReflectionMethod($this->service, 'normalizeTags');
+        $method->setAccessible(true);
+
+        expect($method->invoke($this->service, 'just a string'))->toBe([])
+            ->and($method->invoke($this->service, null))->toBe([])
+            ->and($method->invoke($this->service, '[not valid json'))->toBe([]);
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `normalizeTags()` to decode JSON-encoded string arrays from Qdrant payloads
- Applied at both hydration points in `QdrantService` (search results + scroll/get)
- Fixes `TypeError` on `count()` and `implode()` when tags come back as `'["foo","bar"]'`

Closes #142

## Test plan
- [x] 3 tests for normalizeTags: array passthrough, JSON decode, invalid input
- [x] Full suite: 1197 passed