### PR TITLE
fix(recall): fall back to default bucket when detected project is empty

### DIFF
--- a/app/Mcp/Tools/RecallTool.php
+++ b/app/Mcp/Tools/RecallTool.php
@@ -37,7 +37,8 @@ class RecallTool extends Tool
             return Response::error('A search query of at least 2 characters is required.');
         }
 
-        $project = is_string($request->get('project')) ? $request->get('project') : $this->projectDetector->detect();
+        $projectProvided = is_string($request->get('project'));
+        $project = $projectProvided ? $request->get('project') : $this->projectDetector->detect();
         $limit = is_int($request->get('limit')) ? min($request->get('limit'), 20) : 5;
         $global = (bool) ($request->get('global') ?? false);
 
@@ -51,6 +52,23 @@ class RecallTool extends Tool
         }
 
         $results = $this->tieredSearch->search($query, $filters, $limit, project: $project);
+        $searchedProject = $project;
+        $fallbackUsed = false;
+
+        // Namespace routing fallback: a git-detected project often resolves to a
+        // collection that holds no entries (knowledge frequently lives in the
+        // shared `default` bucket). When an auto-detected scope comes up empty,
+        // retry once against `default` so recall does not silently return zero.
+        // Explicitly requested projects are respected and never fall back.
+        if ($results->isEmpty() && ! $projectProvided && $project !== 'default') {
+            $fallback = $this->tieredSearch->search($query, $filters, $limit, project: 'default');
+
+            if ($fallback->isNotEmpty()) {
+                $results = $fallback;
+                $searchedProject = 'default';
+                $fallbackUsed = true;
+            }
+        }
 
         if ($results->isEmpty()) {
             return Response::text(json_encode([
@@ -58,6 +76,8 @@ class RecallTool extends Tool
                 'meta' => [
                     'query' => $query,
                     'project' => $project,
+                    'searched_project' => $searchedProject,
+                    'fallback_used' => $fallbackUsed,
                     'total' => 0,
                 ],
             ], JSON_THROW_ON_ERROR));
@@ -70,6 +90,8 @@ class RecallTool extends Tool
             'meta' => [
                 'query' => $query,
                 'project' => $project,
+                'searched_project' => $searchedProject,
+                'fallback_used' => $fallbackUsed,
                 'total' => count($formatted),
                 'search_tier' => $results->first()['tier_label'] ?? 'unknown',
             ],

--- a/tests/Unit/Mcp/Tools/RecallToolTest.php
+++ b/tests/Unit/Mcp/Tools/RecallToolTest.php
@@ -44,8 +44,9 @@ describe('recall tool', function (): void {
 
     it('returns empty results when nothing found', function (): void {
         $this->projectDetector->shouldReceive('detect')->once()->andReturn('test-project');
+        // Detected project is empty, so recall also probes the `default` bucket.
         $this->tieredSearch->shouldReceive('search')
-            ->once()
+            ->twice()
             ->andReturn(collect());
 
         $request = new Request(['query' => 'test query']);
@@ -56,7 +57,61 @@ describe('recall tool', function (): void {
         $data = json_decode((string) $response->content(), true);
         expect($data['results'])->toBeEmpty()
             ->and($data['meta']['total'])->toBe(0)
-            ->and($data['meta']['project'])->toBe('test-project');
+            ->and($data['meta']['project'])->toBe('test-project')
+            ->and($data['meta']['fallback_used'])->toBeFalse();
+    });
+
+    it('falls back to the default bucket when a detected project is empty', function (): void {
+        $this->projectDetector->shouldReceive('detect')->once()->andReturn('some-repo');
+
+        // First call (detected project) is empty; second call (default) has a hit.
+        $this->tieredSearch->shouldReceive('search')
+            ->withArgs(fn ($q, $f, $l, $forceTier, $p): bool => $p === 'some-repo')
+            ->once()
+            ->andReturn(collect());
+        $this->tieredSearch->shouldReceive('search')
+            ->withArgs(fn ($q, $f, $l, $forceTier, $p): bool => $p === 'default')
+            ->once()
+            ->andReturn(collect([
+                [
+                    'id' => 'entry-1',
+                    'title' => 'Found in default',
+                    'content' => 'Some content',
+                    'category' => null,
+                    'tags' => [],
+                    'tiered_score' => 0.9,
+                    'tier_label' => 'recent',
+                    'confidence' => 70,
+                    'updated_at' => now()->toIso8601String(),
+                ],
+            ]));
+
+        $this->metadata->shouldReceive('calculateEffectiveConfidence')->once()->andReturn(70);
+        $this->metadata->shouldReceive('isStale')->once()->andReturn(false);
+
+        $request = new Request(['query' => 'test query']);
+        $response = $this->tool->handle($request);
+
+        $data = json_decode((string) $response->content(), true);
+        expect($data['results'])->toHaveCount(1)
+            ->and($data['meta']['project'])->toBe('some-repo')
+            ->and($data['meta']['searched_project'])->toBe('default')
+            ->and($data['meta']['fallback_used'])->toBeTrue();
+    });
+
+    it('does not fall back when a project is explicitly provided', function (): void {
+        $this->projectDetector->shouldNotReceive('detect');
+        $this->tieredSearch->shouldReceive('search')
+            ->withArgs(fn ($q, $f, $l, $forceTier, $p): bool => $p === 'my-project')
+            ->once()
+            ->andReturn(collect());
+
+        $request = new Request(['query' => 'test', 'project' => 'my-project']);
+        $response = $this->tool->handle($request);
+
+        $data = json_decode((string) $response->content(), true);
+        expect($data['meta']['fallback_used'])->toBeFalse()
+            ->and($data['meta']['searched_project'])->toBe('my-project');
     });
 
     it('returns formatted results with confidence and freshness', function (): void {


### PR DESCRIPTION
## What
RecallTool now retries against the shared \`knowledge_default\` collection when a **git-detected** project resolves to an empty collection. Explicitly-provided \`project\` args are respected and never fall back. Recall \`meta\` now reports \`searched_project\` + \`fallback_used\` for diagnosis.

## Why
Recall scopes searches to \`knowledge_<detected-project>\`. When the MCP server runs in a repo whose collection has no entries, knowledge stored in the shared \`knowledge_default\` bucket (e.g. the 239 auto-gathered reference entries) was unreachable and recall returned zero. This is the **namespace-routing half** of the recall=0 bug; the retrieval-resilience half (null-status/null-date tier filtering) is handled separately by #151 (147). Both fixes are required.

## Scope / boundaries
- Touches **only** \`app/Mcp/Tools/RecallTool.php\` + its test. No TieredSearchService changes (147's lock).
- Transitional: once per-category collections (Option A) backfill lands, the default bucket empties and the fallback becomes a harmless no-op; the \`searched_project\`/\`fallback_used\` diagnostics remain useful.

## Files changed
- \`app/Mcp/Tools/RecallTool.php\` — fallback logic + meta fields
- \`tests/Unit/Mcp/Tools/RecallToolTest.php\` — 2 new tests (fallback hit; explicit-project no-fallback), 1 updated

## Tests / quality
- \`pest tests/Unit/Mcp/Tools/RecallToolTest.php\` → **9 passed (39 assertions)**
- \`pint\` → clean
- \`phpstan analyse app/Mcp/Tools/RecallTool.php\` → **No errors** (16 pre-existing errors elsewhere on base are unrelated to this change)

## Verification note
Live end-to-end confirmation is pending — Qdrant + the embedding host are currently down, so live recall returns 0 regardless of routing. Fix is unit-verified and correct-by-design.