### PR TITLE
feat(recall): filter retrieval by subject + author provenance

### DIFF
--- a/app/Services/QdrantService.php
+++ b/app/Services/QdrantService.php
@@ -183,7 +183,7 @@ class QdrantService
             'payload' => $payload,
         ];
 
-        if ($this->hybridEnabled && $this->sparseEmbeddingService instanceof \App\Contracts\SparseEmbeddingServiceInterface) {
+        if ($this->hybridEnabled && $this->sparseEmbeddingService instanceof SparseEmbeddingServiceInterface) {
             $sparseVector = $this->sparseEmbeddingService->generate($text);
             $point['vector'] = [
                 'dense' => $vector,
@@ -336,6 +336,8 @@ class QdrantService
      *     module?: string,
      *     priority?: string,
      *     status?: string,
+     *     subject?: string,
+     *     author?: string,
      *     include_superseded?: bool
      * }  $filters
      * @return Collection<int, array{
@@ -447,7 +449,9 @@ class QdrantService
      *     category?: string,
      *     module?: string,
      *     priority?: string,
-     *     status?: string
+     *     status?: string,
+     *     subject?: string,
+     *     author?: string
      * }  $filters
      * @return Collection<int, array{
      *     id: string|int,
@@ -478,7 +482,7 @@ class QdrantService
         string $project = 'default'
     ): Collection {
         // Fall back to dense search if hybrid not enabled or no sparse service
-        if (! $this->hybridEnabled || ! $this->sparseEmbeddingService instanceof \App\Contracts\SparseEmbeddingServiceInterface) {
+        if (! $this->hybridEnabled || ! $this->sparseEmbeddingService instanceof SparseEmbeddingServiceInterface) {
             return $this->search($query, $filters, $limit, $project);
         }
 
@@ -713,6 +717,8 @@ class QdrantService
      *     module?: string,
      *     priority?: string,
      *     status?: string,
+     *     subject?: string,
+     *     author?: string,
      *     include_superseded?: bool
      * }  $filters
      * @return array<string, mixed>|null
@@ -732,7 +738,7 @@ class QdrantService
         }
 
         // Exact match filters
-        foreach (['category', 'module', 'priority', 'status'] as $field) {
+        foreach (['category', 'module', 'priority', 'status', 'subject', 'author'] as $field) {
             if (isset($filters[$field])) {
                 $must[] = [
                     'key' => $field,

--- a/tests/Unit/Services/QdrantServiceTest.php
+++ b/tests/Unit/Services/QdrantServiceTest.php
@@ -12,8 +12,10 @@ use App\Integrations\Qdrant\Requests\GetPoints;
 use App\Integrations\Qdrant\Requests\ScrollPoints;
 use App\Integrations\Qdrant\Requests\SearchPoints;
 use App\Integrations\Qdrant\Requests\UpsertPoints;
+use App\Services\KnowledgeCacheService;
 use App\Services\QdrantService;
 use Illuminate\Support\Facades\Cache;
+use Mockery\MockInterface;
 use Saloon\Exceptions\Request\ClientException;
 use Saloon\Http\Response;
 
@@ -62,7 +64,7 @@ if (! function_exists('mockCollectionExists')) {
     /**
      * Set up mock for ensureCollection to return success (collection exists).
      */
-    function mockCollectionExists(Mockery\MockInterface $connector, int $times = 1): void
+    function mockCollectionExists(MockInterface $connector, int $times = 1): void
     {
         $response = createMockResponse(true);
         $connector->shouldReceive('send')
@@ -1522,7 +1524,7 @@ describe('getCacheService', function (): void {
 
 describe('search with cache service', function (): void {
     it('uses cache service rememberSearch when cache service is present', function (): void {
-        $mockCacheService = Mockery::mock(\App\Services\KnowledgeCacheService::class);
+        $mockCacheService = Mockery::mock(KnowledgeCacheService::class);
         $serviceWithCache = new QdrantService(
             $this->mockEmbedding,
             384,
@@ -1557,7 +1559,7 @@ describe('search with cache service', function (): void {
 
 describe('getCachedEmbedding with cache service', function (): void {
     it('uses cache service rememberEmbedding when cache service is present', function (): void {
-        $mockCacheService = Mockery::mock(\App\Services\KnowledgeCacheService::class);
+        $mockCacheService = Mockery::mock(KnowledgeCacheService::class);
         $serviceWithCache = new QdrantService(
             $this->mockEmbedding,
             384,
@@ -1593,5 +1595,95 @@ describe('getCachedEmbedding with cache service', function (): void {
         $result = $method->invoke($serviceWithCache, 'test text');
 
         expect($result)->toBe($embedding);
+    });
+});
+
+describe('search with provenance filters (subject/author)', function (): void {
+    function captureSearchFilter(QdrantService $service, array $filters): ?array
+    {
+        // Use reflection to capture the filter built by buildFilter
+        $method = (new ReflectionClass($service))->getMethod('buildFilter');
+        $method->setAccessible(true);
+
+        return $method->invoke($service, $filters);
+    }
+
+    it('adds subject filter as a must condition', function (): void {
+        $filter = captureSearchFilter($this->service, ['subject' => 'dad-journals']);
+
+        expect($filter)->toHaveKey('must');
+        $must = $filter['must'];
+        $subjectCondition = collect($must)->firstWhere('key', 'subject');
+        expect($subjectCondition)->toMatchArray([
+            'key' => 'subject',
+            'match' => ['value' => 'dad-journals'],
+        ]);
+    });
+
+    it('adds author filter as a must condition', function (): void {
+        $filter = captureSearchFilter($this->service, ['author' => 'jordan']);
+
+        expect($filter)->toHaveKey('must');
+        $must = $filter['must'];
+        $authorCondition = collect($must)->firstWhere('key', 'author');
+        expect($authorCondition)->toMatchArray([
+            'key' => 'author',
+            'match' => ['value' => 'jordan'],
+        ]);
+    });
+
+    it('combines subject, author, and category into 3 must conditions plus default superseded', function (): void {
+        $filter = captureSearchFilter($this->service, [
+            'subject' => 'dad-journals',
+            'author' => 'jordan',
+            'category' => 'personal',
+        ]);
+
+        expect($filter)->toHaveKey('must');
+        expect($filter['must'])->toHaveCount(4);
+
+        $keys = collect($filter['must'])->pluck('key')->filter()->values()->all();
+        expect($keys)->toContain('subject', 'author', 'category');
+    });
+
+    it('returns only default superseded condition when no filters provided', function (): void {
+        $filter = captureSearchFilter($this->service, []);
+
+        expect($filter)->toHaveKey('must');
+        expect($filter['must'])->toHaveCount(1);
+        expect($filter['must'][0])->toHaveKey('is_empty');
+        expect($filter['must'][0]['is_empty']['key'])->toBe('superseded_by');
+    });
+
+    it('drives subject filter via public search() path with mocked connector', function (): void {
+        $this->mockEmbedding->shouldReceive('generate')
+            ->with('test query')
+            ->once()
+            ->andReturn([0.1, 0.2, 0.3]);
+
+        mockCollectionExists($this->mockConnector);
+
+        $capturedFilter = null;
+        $this->mockConnector->shouldReceive('send')
+            ->with(Mockery::on(function ($request) use (&$capturedFilter) {
+                if ($request instanceof SearchPoints) {
+                    $ref = new ReflectionClass($request);
+                    $prop = $ref->getProperty('filter');
+                    $prop->setAccessible(true);
+                    $capturedFilter = $prop->getValue($request);
+                }
+
+                return true;
+            }))
+            ->once()
+            ->andReturn(createMockResponse(true, 200, ['result' => []]));
+
+        $this->service->search('test query', ['subject' => 'dad-journals', 'author' => 'jordan']);
+
+        expect($capturedFilter)->not()->toBeNull();
+        expect($capturedFilter)->toHaveKey('must');
+
+        $mustKeys = collect($capturedFilter['must'])->pluck('key')->filter()->values()->all();
+        expect($mustKeys)->toContain('subject', 'author');
     });
 });


### PR DESCRIPTION
## Summary

- Adds `subject` and `author` provenance filters to Qdrant retrieval queries
- Edits one source file: `app/Services/QdrantService.php::buildFilter()`
- Filter keys are `subject` and `author` (lowercase, top-level, nullable) — locked contract with Advisor 148

## Files Changed

- `app/Services/QdrantService.php` — Added `subject` and `author` to the exact-match loop in `buildFilter()` + updated `@param` array-shape on `buildFilter()`, `search()`, and `hybridSearch()`
- `tests/Unit/Services/QdrantServiceTest.php` — 5 new tests covering subject-only, author-only, combined, empty, and full public `search()` path

## Verification

```
vendor/bin/pest tests/Unit/Services/QdrantServiceTest.php   → 62 passed
vendor/bin/pest tests/Unit                                  → 602 passed, 1 skipped
vendor/bin/pint                                              → {"result":"pass"}
vendor/bin/phpstan app/Services/QdrantService.php            → [OK] No errors
```

## Key Diff

```diff
- foreach (['category', 'module', 'priority', 'status'] as $field) {
+ foreach (['category', 'module', 'priority', 'status', 'subject', 'author'] as $field) {
```