### PR TITLE
fix(recall): align similarity-floor fallback to config (dead 0.7→0.3) to prevent silent recall regression

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ use App\Contracts\EmbeddingServiceInterface;
 use App\Contracts\HealthCheckInterface;
 use App\Services\DailyLogService;
 use App\Services\DeletionTracker;
+use App\Services\EmbeddingService;
 use App\Services\EnhancementQueueService;
 use App\Services\EntryMetadataService;
 use App\Services\GitContextService;
@@ -120,34 +121,34 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         // Runtime environment (must be first)
-        $this->app->singleton(RuntimeEnvironment::class, fn (): \App\Services\RuntimeEnvironment => new RuntimeEnvironment);
+        $this->app->singleton(RuntimeEnvironment::class, fn (): RuntimeEnvironment => new RuntimeEnvironment);
 
         // Knowledge path service
-        $this->app->singleton(KnowledgePathService::class, fn ($app): \App\Services\KnowledgePathService => new KnowledgePathService(
+        $this->app->singleton(KnowledgePathService::class, fn ($app): KnowledgePathService => new KnowledgePathService(
             $app->make(RuntimeEnvironment::class)
         ));
 
         // Embedding service
-        $this->app->singleton(EmbeddingServiceInterface::class, function (): \App\Services\StubEmbeddingService|\App\Services\EmbeddingService {
+        $this->app->singleton(EmbeddingServiceInterface::class, function (): StubEmbeddingService|EmbeddingService {
             if (config('search.embedding_provider') === 'none') {
                 return new StubEmbeddingService;
             }
 
-            return new \App\Services\EmbeddingService(
+            return new EmbeddingService(
                 config('search.qdrant.embedding_server', 'http://localhost:8001')
             );
         });
 
         // Knowledge cache service
-        $this->app->singleton(KnowledgeCacheService::class, fn (): \App\Services\KnowledgeCacheService => new KnowledgeCacheService);
+        $this->app->singleton(KnowledgeCacheService::class, fn (): KnowledgeCacheService => new KnowledgeCacheService);
 
         // Deletion tracker service
-        $this->app->singleton(DeletionTracker::class, fn ($app): \App\Services\DeletionTracker => new DeletionTracker(
+        $this->app->singleton(DeletionTracker::class, fn ($app): DeletionTracker => new DeletionTracker(
             $app->make(KnowledgePathService::class)
         ));
 
         // Write gate service
-        $this->app->singleton(WriteGateService::class, fn (): \App\Services\WriteGateService => new WriteGateService);
+        $this->app->singleton(WriteGateService::class, fn (): WriteGateService => new WriteGateService);
 
         // Project detector service
         $this->app->singleton(ProjectDetectorService::class, fn ($app): ProjectDetectorService => new ProjectDetectorService(
@@ -155,28 +156,28 @@ class AppServiceProvider extends ServiceProvider
         ));
 
         // Qdrant vector database service
-        $this->app->singleton(QdrantService::class, fn ($app): \App\Services\QdrantService => new QdrantService(
+        $this->app->singleton(QdrantService::class, fn ($app): QdrantService => new QdrantService(
             $app->make(EmbeddingServiceInterface::class),
             (int) config('search.embedding_dimension', 1024),
-            (float) config('search.minimum_similarity', 0.7),
+            (float) config('search.minimum_similarity', 0.3),
             (int) config('search.qdrant.cache_ttl', 604800),
             (bool) config('search.qdrant.secure', false),
             cacheService: $app->make(KnowledgeCacheService::class)
         ));
 
         // Tiered search service
-        $this->app->singleton(TieredSearchService::class, fn ($app): \App\Services\TieredSearchService => new TieredSearchService(
+        $this->app->singleton(TieredSearchService::class, fn ($app): TieredSearchService => new TieredSearchService(
             $app->make(QdrantService::class),
             $app->make(EntryMetadataService::class),
         ));
 
         // Remote sync service
-        $this->app->singleton(RemoteSyncService::class, fn ($app): \App\Services\RemoteSyncService => new RemoteSyncService(
+        $this->app->singleton(RemoteSyncService::class, fn ($app): RemoteSyncService => new RemoteSyncService(
             $app->make(KnowledgePathService::class)
         ));
 
         // Daily log staging service
-        $this->app->singleton(DailyLogService::class, fn ($app): \App\Services\DailyLogService => new DailyLogService(
+        $this->app->singleton(DailyLogService::class, fn ($app): DailyLogService => new DailyLogService(
             $app->make(KnowledgePathService::class)
         ));
 
@@ -184,10 +185,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(HealthCheckInterface::class, fn (): HealthCheckService => new HealthCheckService);
 
         // Ollama service
-        $this->app->singleton(OllamaService::class, fn (): \App\Services\OllamaService => new OllamaService);
+        $this->app->singleton(OllamaService::class, fn (): OllamaService => new OllamaService);
 
         // Enhancement queue service
-        $this->app->singleton(EnhancementQueueService::class, fn ($app): \App\Services\EnhancementQueueService => new EnhancementQueueService(
+        $this->app->singleton(EnhancementQueueService::class, fn ($app): EnhancementQueueService => new EnhancementQueueService(
             $app->make(KnowledgePathService::class)
         ));
     }

--- a/config/search.php
+++ b/config/search.php
@@ -48,6 +48,11 @@ return [
     |--------------------------------------------------------------------------
     | Search Configuration
     |--------------------------------------------------------------------------
+    |
+    | minimum_similarity: dense-cosine pre-rank floor; tiering does the real ranking.
+    | 0.3 is intentionally lenient so the tiered scorer (relevance*confidence*freshness)
+    | can rank moderate matches instead of cutting them prematurely.
+    |
     */
 
     'minimum_similarity' => env('SEARCH_MIN_SIMILARITY', 0.3),

--- a/tests/Feature/AppServiceProviderTest.php
+++ b/tests/Feature/AppServiceProviderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Contracts\EmbeddingServiceInterface;
 use App\Contracts\HealthCheckInterface;
+use App\Providers\AppServiceProvider;
 use App\Services\EmbeddingService;
 use App\Services\HealthCheckService;
 use App\Services\KnowledgePathService;
@@ -80,6 +81,25 @@ describe('AppServiceProvider', function (): void {
         expect($service)->toBeInstanceOf(QdrantService::class);
     });
 
+    it('uses config default 0.3 for minimum_similarity when no env overrides', function (): void {
+        expect(config('search.minimum_similarity'))->toBe(0.3);
+    });
+
+    it('binds QdrantService with scoreThreshold matching config minimum_similarity', function (): void {
+        $mockEmbedding = Mockery::mock(EmbeddingServiceInterface::class);
+        app()->instance(EmbeddingServiceInterface::class, $mockEmbedding);
+
+        app()->forgetInstance(QdrantService::class);
+
+        $service = app(QdrantService::class);
+
+        $reflection = new ReflectionClass($service);
+        $property = $reflection->getProperty('scoreThreshold');
+        $property->setAccessible(true);
+
+        expect($property->getValue($service))->toBe(0.3);
+    });
+
     it('registers HealthCheckService', function (): void {
         $service = app(HealthCheckInterface::class);
 
@@ -133,7 +153,7 @@ describe('AppServiceProvider user config loading', function (): void {
         app()->instance(KnowledgePathService::class, $mock);
 
         // Call boot to load user config
-        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider = new AppServiceProvider(app());
         $provider->boot();
 
         expect(config('search.qdrant.host'))->toBe('custom-host');
@@ -157,7 +177,7 @@ describe('AppServiceProvider user config loading', function (): void {
 
         app()->instance(KnowledgePathService::class, $mock);
 
-        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider = new AppServiceProvider(app());
         $provider->boot();
 
         expect(config('search.qdrant.host'))->toBe('secure-host');
@@ -181,7 +201,7 @@ describe('AppServiceProvider user config loading', function (): void {
 
         app()->instance(KnowledgePathService::class, $mock);
 
-        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider = new AppServiceProvider(app());
         $provider->boot();
 
         expect(config('search.qdrant.collection'))->toBe('my-custom-collection');
@@ -203,7 +223,7 @@ describe('AppServiceProvider user config loading', function (): void {
 
         app()->instance(KnowledgePathService::class, $mock);
 
-        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider = new AppServiceProvider(app());
         $provider->boot();
 
         expect(config('search.qdrant.embedding_server'))->toBe('http://custom-embeddings:9001');
@@ -229,7 +249,7 @@ describe('AppServiceProvider user config loading', function (): void {
 
         app()->instance(KnowledgePathService::class, $mock);
 
-        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider = new AppServiceProvider(app());
         $provider->boot();
 
         expect(config('search.qdrant.host'))->toBe('qdrant-server');
@@ -252,7 +272,7 @@ describe('AppServiceProvider user config loading', function (): void {
 
         app()->instance(KnowledgePathService::class, $mock);
 
-        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider = new AppServiceProvider(app());
         $provider->boot();
 
         // Config should remain unchanged
@@ -276,7 +296,7 @@ describe('AppServiceProvider user config loading', function (): void {
 
         app()->instance(KnowledgePathService::class, $mock);
 
-        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider = new AppServiceProvider(app());
         $provider->boot();
 
         // Config should remain unchanged
@@ -298,7 +318,7 @@ describe('AppServiceProvider user config loading', function (): void {
 
         app()->instance(KnowledgePathService::class, $mock);
 
-        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider = new AppServiceProvider(app());
         $provider->boot();
 
         expect(config('search.qdrant.host'))->toBe('default-host');
@@ -329,7 +349,7 @@ describe('AppServiceProvider user config loading', function (): void {
 
         app()->instance(KnowledgePathService::class, $mock);
 
-        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider = new AppServiceProvider(app());
         $provider->boot();
 
         // Config should remain unchanged since values are not strings
@@ -357,7 +377,7 @@ describe('AppServiceProvider user config loading', function (): void {
 
         app()->instance(KnowledgePathService::class, $mock);
 
-        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider = new AppServiceProvider(app());
         $provider->boot();
 
         expect(config('search.qdrant.host'))->toBe('qdrant-server');
@@ -395,7 +415,7 @@ describe('AppServiceProvider user config loading', function (): void {
 
         app()->instance(KnowledgePathService::class, $mock);
 
-        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider = new AppServiceProvider(app());
         $provider->boot();
 
         $criteria = config('write-gate.criteria');
@@ -432,7 +452,7 @@ describe('AppServiceProvider user config loading', function (): void {
 
         app()->instance(KnowledgePathService::class, $mock);
 
-        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider = new AppServiceProvider(app());
         $provider->boot();
 
         $criteria = config('write-gate.criteria');
@@ -465,7 +485,7 @@ describe('AppServiceProvider user config loading', function (): void {
 
         app()->instance(KnowledgePathService::class, $mock);
 
-        $provider = new \App\Providers\AppServiceProvider(app());
+        $provider = new AppServiceProvider(app());
         $provider->boot();
 
         $criteria = config('write-gate.criteria');


### PR DESCRIPTION
## What

Align the `AppServiceProvider::register()` fallback for `config('search.minimum_similarity', ...)` from `0.7` to `0.3`, matching the already-live config default in `config/search.php`.

## Why

The config file already defaults `minimum_similarity` to `0.3`. However the provider binding had a **dead fallback of `0.7`** — if the config key is ever removed or renamed, recall would silently tighten from 0.3 to 0.7, cutting moderate matches before the tiered scorer can rank them. This PR removes that footgun.

No behaviour change today: the config key exists and `config()` returns `0.3`. The fix is purely defensive.

## Files changed

| File | Change |
|---|---|
| `config/search.php` | Improve doc comment to explain the 0.3 floor rationale |
| `app/Providers/AppServiceProvider.php` | Fallback `0.7` → `0.3` on line 161 |
| `tests/Feature/AppServiceProviderTest.php` | Two new tests asserting effective default resolves to `0.3` |

## Verification

- `vendor/bin/pest tests/Unit` → 597 passed, 1 skipped
- `vendor/bin/pint config/search.php app/Providers/AppServiceProvider.php` → `{"result":"pass"}`
- `vendor/bin/phpstan analyse app/Providers/AppServiceProvider.php config/search.php` → `[OK] No errors`

## Key diff

Only one line of logic changed:

```diff
- (float) config('search.minimum_similarity', 0.7),
+ (float) config('search.minimum_similarity', 0.3),
```