### PR TITLE
fix: honor APP_TIMEZONE for date-sensitive operations

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -17,6 +17,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Timezone
+    |--------------------------------------------------------------------------
+    |
+    | Date handling (daily digests, staleness cutoffs) should follow the
+    | operator's local day, not UTC. Defaults to UTC when unset.
+    |
+    */
+
+    'timezone' => env('APP_TIMEZONE', 'UTC'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Version
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
## The bug

`config/app.php` had no `timezone` key, so `Carbon::today()` / `yesterday()` always ran in UTC. On odin the nightly 23:00 MST synthesis cron generated digests dated **tomorrow** and the digest recency window skewed 7 hours.

## The fix

One config key: `'timezone' => env('APP_TIMEZONE', 'UTC')`. Default unchanged (UTC) — opt-in per deployment.

## Verification

Live on odin with `APP_TIMEZONE=America/Phoenix`: `synthesize --digest --dry-run` at 21:45 MST now reports `Generating digest for 2026-07-02` (was 2026-07-03). Synthesize test suite: 15/15 passing (tests pin Carbon::setTestNow, unaffected by the default).