### PR TITLE
fix: skip duplicate detection when upserting daily digest

### DIFF
--- a/app/Commands/SynthesizeCommand.php
+++ b/app/Commands/SynthesizeCommand.php
@@ -193,7 +193,7 @@ class SynthesizeCommand extends Command
             'priority' => 'medium',
             'confidence' => 85,
             'status' => 'validated',
-        ], $project);
+        ], $project, checkDuplicates: false);
 
         info("Digest created for {$today}");
 

--- a/tests/Feature/Commands/SynthesizeCommandTest.php
+++ b/tests/Feature/Commands/SynthesizeCommandTest.php
@@ -139,7 +139,7 @@ describe('digest', function (): void {
             ->once()
             ->with(Mockery::on(fn ($data): bool => str_contains((string) $data['title'], 'Daily Synthesis - 2026-02-03')
                 && $data['status'] === 'validated'
-                && in_array('daily-synthesis', $data['tags'])), 'default')
+                && in_array('daily-synthesis', $data['tags'])), 'default', false)
             ->andReturn(true);
 
         $this->artisan('synthesize', ['--digest' => true])
@@ -307,7 +307,7 @@ describe('project scoping', function (): void {
 
         $this->qdrantMock->shouldReceive('upsert')
             ->once()
-            ->with(Mockery::type('array'), 'homelab')
+            ->with(Mockery::type('array'), 'homelab', false)
             ->andReturn(true);
 
         $this->qdrantMock->shouldReceive('scroll')


### PR DESCRIPTION
Follow-up to #156, found by running the fixed synthesis in production on odin: the digest upsert ran with duplicate detection enabled, and since consecutive days of similar activity produce similar digest content, `DuplicateEntryException` fails the whole nightly run (observed live: 07-02 digest at 96%+ similarity with 07-03 digest → exit 1).

The title/date existence check earlier in `runDigest` already guards true duplicates — same-day reruns skip cleanly. Day-over-day similarity is expected behavior for digests, so `checkDuplicates: false` on this one upsert.

Tests pin the new argument; 15/15 passing.