### PR TITLE
fix: queue enhancements under the resolved project namespace

### DIFF
--- a/app/Commands/KnowledgeAddCommand.php
+++ b/app/Commands/KnowledgeAddCommand.php
@@ -192,7 +192,7 @@ class KnowledgeAddCommand extends Command
 
         // Queue for Ollama enhancement unless skipped
         if (! $skipEnhance && (bool) config('search.ollama.enabled', true)) {
-            $enhancementQueue->queue($data);
+            $enhancementQueue->queue($data, $this->resolveProject());
         }
 
         info('Knowledge entry created!');

--- a/tests/Feature/Commands/KnowledgeAddCommandTest.php
+++ b/tests/Feature/Commands/KnowledgeAddCommandTest.php
@@ -376,3 +376,25 @@ it('passes checkDuplicates=true by default', function (): void {
         '--content' => 'Content',
     ])->assertSuccessful();
 });
+
+it('queues enhancement under the resolved project namespace', function (): void {
+    mockProjectDetector('mesh-status');
+
+    $this->mockQdrant->shouldReceive('upsert')
+        ->once()
+        ->with(Mockery::any(), 'mesh-status', Mockery::any())
+        ->andReturn(true);
+
+    $mockQueue = Mockery::mock(\App\Services\EnhancementQueueService::class);
+    $mockQueue->shouldReceive('queue')
+        ->once()
+        ->with(Mockery::type('array'), 'mesh-status');
+    $this->app->instance(\App\Services\EnhancementQueueService::class, $mockQueue);
+
+    config(['search.ollama.enabled' => true]);
+
+    $this->artisan('add', [
+        'title' => 'Project Scoped Entry',
+        '--content' => 'Enhancement must look in the same collection the entry was stored in',
+    ])->assertSuccessful();
+});

--- a/tests/Feature/KnowledgeAddCommandTest.php
+++ b/tests/Feature/KnowledgeAddCommandTest.php
@@ -199,7 +199,7 @@ it('queues entry for enhancement by default', function (): void {
 
     $this->enhancementQueue->shouldReceive('queue')
         ->once()
-        ->with(Mockery::on(fn ($data): bool => $data['title'] === 'Enhanced Entry'));
+        ->with(Mockery::on(fn ($data): bool => $data['title'] === 'Enhanced Entry'), 'default');
 
     $this->artisan('add', [
         'title' => 'Enhanced Entry',


### PR DESCRIPTION
The enhancement queue enqueued entries without a project, defaulting to `default`, while storage five lines up is project-aware. `enhance:worker` then called `getById(id, 'default')`, found nothing in `knowledge_default`, and recorded a failure.

Impact: every enhancement since project namespacing took over has failed — queue status shows 8,560 failures against 3,512 processed, last success 2026-03-09. Entries created since then never received Ollama tags/summary/concepts.

Fix is the one-line project pass-through at the enqueue call site, plus a regression test asserting the queue receives the resolved project.

Verified: full KnowledgeAddCommandTest suite green (25 tests); PHPStan errors unchanged from master (52 pre-existing, none in touched files).