### PR TITLE
fix: persist enhancement fields and commit hash through upsert round-trips

### DIFF
--- a/app/Services/QdrantService.php
+++ b/app/Services/QdrantService.php
@@ -166,6 +166,14 @@ class QdrantService
             'superseded_reason' => $entry['superseded_reason'] ?? null,
         ];
 
+        // Enhancement fields are optional: only present once the Ollama worker
+        // has processed the entry, and must survive later re-upserts.
+        foreach (['enhanced', 'enhanced_at', 'summary', 'concepts'] as $enhancementField) {
+            if (array_key_exists($enhancementField, $entry)) {
+                $payload[$enhancementField] = $entry[$enhancementField];
+            }
+        }
+
         $point = ['id' => $entry['id'], 'payload' => $payload];
 
         if ($this->hybridEnabled && $this->sparseEmbeddingService instanceof SparseEmbeddingServiceInterface) {
@@ -661,6 +669,11 @@ class QdrantService
             'superseded_by' => $p['superseded_by'] ?? null,
             'superseded_date' => $p['superseded_date'] ?? null,
             'superseded_reason' => $p['superseded_reason'] ?? null,
+            'commit' => $p['commit'] ?? null,
+            'enhanced' => $p['enhanced'] ?? null,
+            'enhanced_at' => $p['enhanced_at'] ?? null,
+            'summary' => $p['summary'] ?? null,
+            'concepts' => $p['concepts'] ?? null,
         ];
     }
 

--- a/tests/Unit/Services/QdrantServiceTest.php
+++ b/tests/Unit/Services/QdrantServiceTest.php
@@ -1574,3 +1574,45 @@ describe('findByTitleAndCommit error handling', function (): void {
         expect($this->service->upsert($entry, 'default', true))->toBeTrue();
     });
 });
+
+describe('enhancement field round-trip', function (): void {
+    it('persists enhancement fields through updateFields', function (): void {
+        mockCollectionExists($this->mockQdrant, 2);
+
+        $this->mockQdrant->shouldReceive('getPoints')
+            ->once()
+            ->andReturn([
+                makeScoredPoint('enh-1', 0.0, [
+                    'title' => 'Entry',
+                    'content' => 'Body',
+                    'commit' => 'abc123',
+                ]),
+            ]);
+
+        $this->mockEmbedding->shouldReceive('embed')
+            ->once()
+            ->andReturn([0.1, 0.2, 0.3]);
+
+        $this->mockQdrant->shouldReceive('upsert')
+            ->once()
+            ->with(Mockery::any(), Mockery::on(function (array $points): bool {
+                $payload = $points[0]['payload'];
+
+                return ($payload['enhanced'] ?? null) === true
+                    && ($payload['enhanced_at'] ?? null) === '2026-07-03T00:00:00+00:00'
+                    && ($payload['summary'] ?? null) === 'A summary'
+                    && ($payload['concepts'] ?? null) === ['mesh', 'router']
+                    && ($payload['commit'] ?? null) === 'abc123';
+            }))
+            ->andReturn(makeUpsertResult());
+
+        $result = $this->service->updateFields('enh-1', [
+            'enhanced' => true,
+            'enhanced_at' => '2026-07-03T00:00:00+00:00',
+            'summary' => 'A summary',
+            'concepts' => ['mesh', 'router'],
+        ]);
+
+        expect($result)->toBeTrue();
+    });
+});


### PR DESCRIPTION
Follow-up to #162. With the queue routing fixed, enhancement results reached the right collection but only half-applied: `upsert()` rebuilds payloads from a fixed field list that omitted `enhanced`, `enhanced_at`, `summary`, and `concepts`, so the worker's update dropped them (tags/category survived only because they're whitelisted). Without the `enhanced` marker there is no way to find unenhanced entries for backfill.

`mapScoredPointToEntry()` had the same gap plus `commit` — any getById→upsert cycle (usage increment, updateFields) erased the stored commit hash that `findByTitleAndCommit` dedup depends on.

Fix: carry the four enhancement fields through `upsert()` when present, and round-trip them (plus `commit`) in `mapScoredPointToEntry()`. Regression test asserts the full round-trip.

Verified: full suite green (1,134 passed), PHPStan unchanged from master (52 pre-existing).