### PR TITLE
fix: exclude archived entries from search by default

### DIFF
--- a/app/Commands/KnowledgeSearchCommand.php
+++ b/app/Commands/KnowledgeSearchCommand.php
@@ -25,7 +25,8 @@ class KnowledgeSearchCommand extends Command
                             {--status= : Filter by status}
                             {--limit=20 : Maximum number of results}
                             {--semantic : Use semantic search if available}
-                            {--include-superseded : Include superseded entries in results}
+                             {--include-superseded : Include superseded entries in results}
+                             {--include-archived : Include archived entries in results}
                             {--project= : Override project namespace}
                             {--global : Search across all projects}
                             {--collection= : Search a raw Qdrant collection directly (bypasses knowledge_ prefix)}';
@@ -46,6 +47,7 @@ class KnowledgeSearchCommand extends Command
         $limit = (int) $this->option('limit');
         $this->option('semantic');
         $includeSuperseded = (bool) $this->option('include-superseded');
+        $includeArchived = (bool) $this->option('include-archived');
 
         // Require at least one search parameter for entries
         if ($query === null && $tag === null && $category === null && $module === null && $priority === null && $status === null) {
@@ -65,6 +67,9 @@ class KnowledgeSearchCommand extends Command
 
         if ($includeSuperseded) {
             $filters['include_superseded'] = true;
+        }
+        if ($includeArchived) {
+            $filters['include_archived'] = true;
         }
 
         // Use project-aware search

--- a/app/Services/QdrantService.php
+++ b/app/Services/QdrantService.php
@@ -611,12 +611,18 @@ class QdrantService
     private function buildFilter(array $filters): ?array
     {
         $includeSuperseded = (bool) ($filters['include_superseded'] ?? false);
-        unset($filters['include_superseded']);
+        $includeArchived = (bool) ($filters['include_archived'] ?? false);
+        unset($filters['include_superseded'], $filters['include_archived']);
 
         $must = [];
+        $mustNot = [];
 
         if (! $includeSuperseded) {
             $must[] = ['is_empty' => ['key' => 'superseded_by']];
+        }
+
+        if (! $includeArchived) {
+            $mustNot[] = ['key' => 'status', 'match' => ['value' => 'archived']];
         }
 
         foreach (['category', 'module', 'priority', 'status'] as $field) {
@@ -629,7 +635,15 @@ class QdrantService
             $must[] = ['key' => 'tags', 'match' => ['value' => $filters['tag']]];
         }
 
-        return $must === [] ? null : ['must' => $must];
+        $filter = [];
+        if ($must !== []) {
+            $filter['must'] = $must;
+        }
+        if ($mustNot !== []) {
+            $filter['must_not'] = $mustNot;
+        }
+
+        return $filter === [] ? null : $filter;
     }
 
     /**


### PR DESCRIPTION
Closes #165

Search (keyword + semantic) now filters payload status=archived via must_not on the Qdrant query. `--include-archived` flag restores old behavior for recovery workflows. Mirrors entries-listing semantics.

Authored by cloud-smart worker knowledge-165; PR opened on its behalf (worker printed the create link instead of creating).